### PR TITLE
test(pi-tidy-subagents): prevent parallel label jitter

### DIFF
--- a/packages/pi-tidy-subagents/test/parallel-render-regression.test.ts
+++ b/packages/pi-tidy-subagents/test/parallel-render-regression.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { renderLines } from "../render.js";
+
+const stripAnsi = (line: string): string => line.replace(/\x1b\[[0-9;]*m/g, "");
+
+test("parallel running label stays in one column across live frames", () => {
+ const child: any = {
+  index: 0, id: "parallel", label: "verifier", reason: "verify parallel rendering", prompt: "",
+  status: "running", model: "m", thinking: "high", toolCount: 3, tokens: 0,
+  activities: [], activeTools: [
+   { name: "bash", activityIndex: 0 },
+   { name: "bash", activityIndex: 0 },
+   { name: "bash", activityIndex: 0 },
+  ],
+  eventCount: 0, startedAt: 1, response: "", artifactPath: "/parallel",
+ };
+ const details: any = { children: [child] };
+ const frames = [0, 120, 240, 360, 480, 600, 720, 840, 960, 1_080]
+  .map((now) => renderLines(details, false, now, 120).map(stripAnsi))
+  .map((lines) => lines.find((line) => line.includes("parallel 3 tools running"))!);
+ const columns = frames.map((line) => line.indexOf("parallel"));
+
+ assert.ok(frames.every(Boolean), "every live frame must render the parallel summary");
+ assert.deepEqual([...new Set(columns)], [10], frames.join("\n"));
+});


### PR DESCRIPTION
## Summary
- add a renderer regression for parallel child tool activity
- assert `parallel 3 tools running` remains at one fixed column across every historical spinner timestamp
- protect the stable running-dot behavior that removed the two-column jump

## Root cause
The original animated renderer classified only the `⠋` frame as tool activity. The remaining nine frames received the text indent, moving `parallel` from column 10 to column 12. The current renderer uses a stable running dot; this test locks the exact user-visible invariant.

## Verification
- `npm test`
- `npm run check`
- `git diff --check`