### PR TITLE
fix(tools): keep completion ages live

### DIFF
--- a/packages/pi-tidy-tools/README.md
+++ b/packages/pi-tidy-tools/README.md
@@ -99,7 +99,7 @@ Mirrors a clean, theme-agnostic palette + icon mapping:
 | `write` `edit`           | ✏️   | yellow  |
 | `bash`                   | ⚡   | magenta |
 
-- Settled calls show a compact completion age such as `(<1m ago)` or `(1h3m ago)`; the timestamp persists with the result across session restarts
+- Settled calls show a compact completion age such as `(<1m ago)` or `(1h3m ago)`; it keeps advancing while displayed, including after `/reload` or session resume, and the timestamp persists with the result
 - Paths collapse `$HOME` → `~`
 - `edit` shows `+adds/-dels`; text `write` shows line count; `bash` shows status + elapsed time
 - `grep` shows `N matches in M files`; `find`/`ls` show file or entry counts

--- a/packages/pi-tidy-tools/index.ts
+++ b/packages/pi-tidy-tools/index.ts
@@ -486,6 +486,43 @@ export default function (pi: ExtensionAPI) {
 	const pathByCallId = new Map<string, string>();
 	const startedAtByCallId = new Map<string, number>();
 	const elapsedTimerByCallId = new Map<string, ReturnType<typeof setInterval>>();
+	const ageRefreshByCallId = new Map<string, { completedAt: number; invalidate: () => void; nextAt: number }>();
+	let ageRefreshTimer: ReturnType<typeof setTimeout> | undefined;
+
+	const nextAgeRefreshAt = (completedAt: number, now: number): number => {
+		const age = Math.max(0, now - completedAt);
+		if (age < 24 * 60 * 60_000) return completedAt + (Math.floor(age / 60_000) + 1) * 60_000;
+		if (age < 30 * 24 * 60 * 60_000) return completedAt + (Math.floor(age / 3_600_000) + 1) * 3_600_000;
+		return completedAt + (Math.floor(age / 86_400_000) + 1) * 86_400_000;
+	};
+	const scheduleAgeRefresh = (): void => {
+		if (ageRefreshTimer) clearTimeout(ageRefreshTimer);
+		if (ageRefreshByCallId.size === 0) { ageRefreshTimer = undefined; return; }
+		const now = Date.now();
+		const next = Math.min(...[...ageRefreshByCallId.values()].map(({ nextAt }) => nextAt));
+		ageRefreshTimer = setTimeout(() => {
+			ageRefreshTimer = undefined;
+			const refreshNow = Date.now();
+			for (const entry of ageRefreshByCallId.values()) {
+				if (entry.nextAt > refreshNow) continue;
+				entry.nextAt = nextAgeRefreshAt(entry.completedAt, refreshNow);
+				entry.invalidate();
+			}
+			scheduleAgeRefresh();
+		}, Math.max(1, next - now));
+		ageRefreshTimer.unref?.();
+	};
+	const registerAgeRefresh = (id: string, completedAt: number, invalidate: () => void): void => {
+		const previous = ageRefreshByCallId.get(id);
+		const unchanged = previous?.completedAt === completedAt;
+		ageRefreshByCallId.set(id, { completedAt, invalidate, nextAt: unchanged ? previous.nextAt : nextAgeRefreshAt(completedAt, Date.now()) });
+		if (!unchanged || !ageRefreshTimer) scheduleAgeRefresh();
+	};
+	const clearAgeRefresh = (): void => {
+		if (ageRefreshTimer) clearTimeout(ageRefreshTimer);
+		ageRefreshTimer = undefined;
+		ageRefreshByCallId.clear();
+	};
 
 	pi.on("tool_execution_start", async (e: any) => {
 		if (!startedAtByCallId.has(e.toolCallId)) startedAtByCallId.set(e.toolCallId, Date.now());
@@ -527,6 +564,12 @@ export default function (pi: ExtensionAPI) {
 		startedAtByCallId.clear();
 		for (const timer of elapsedTimerByCallId.values()) clearInterval(timer);
 		elapsedTimerByCallId.clear();
+	});
+
+	pi.on("session_shutdown", async () => {
+		for (const timer of elapsedTimerByCallId.values()) clearInterval(timer);
+		elapsedTimerByCallId.clear();
+		clearAgeRefresh();
 	});
 
 	// Render the recap message as width-aware colored lines.
@@ -651,6 +694,9 @@ export default function (pi: ExtensionAPI) {
 					: startedAt === undefined ? 0 : Date.now() - startedAt;
 				const persistedCompletedAt = Number(result?.details?.piTidyCompletedAt);
 				const completedAt = Number.isFinite(persistedCompletedAt) ? persistedCompletedAt : undefined;
+				if (toolCallId && completedAt !== undefined && typeof context?.invalidate === "function") {
+					registerAgeRefresh(toolCallId, completedAt, () => context.invalidate());
+				}
 				const lines = () => buildToolBlock(name, context?.args ?? {}, result, {
 					isError,
 					expanded: options?.expanded ?? false,

--- a/packages/pi-tidy-tools/test/extension.test.ts
+++ b/packages/pi-tidy-tools/test/extension.test.ts
@@ -173,6 +173,126 @@ test("restored settled tools clear timers started during call hydration", () => 
   }
 });
 
+test("settled tool completion ages advance while the turn remains active", async () => {
+  const harness = await registerEnabledExtension();
+  const originalNow = Date.now;
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  let now = 1_000;
+  let invalidations = 0;
+  const timers: Array<{ callback: () => void; delay: number; unref(): void }> =
+    [];
+  const cleared: unknown[] = [];
+  Date.now = () => now;
+  globalThis.setTimeout = ((callback: () => void, delay: number) => {
+    const timer = { callback, delay, unref() {} };
+    timers.push(timer);
+    return timer;
+  }) as any;
+  globalThis.clearTimeout = ((timer: unknown) => cleared.push(timer)) as any;
+  try {
+    const bash = harness.tools.get("bash");
+    const context = {
+      isPartial: true,
+      toolCallId: "advancing-age",
+      args: { command: "true", reasoning: "finish quickly" },
+      invalidate() {
+        invalidations += 1;
+      },
+    };
+    const theme = { bg: (_name: string, text: string) => text };
+    await harness.events.get("tool_execution_start")!({
+      toolName: "bash",
+      toolCallId: context.toolCallId,
+      args: context.args,
+    });
+    await harness.events.get("tool_execution_end")!({
+      toolName: "bash",
+      toolCallId: context.toolCallId,
+    });
+    const augmented = await harness.events.get("tool_result")!({
+      toolName: "bash",
+      toolCallId: context.toolCallId,
+      details: {},
+    });
+    const settled = bash.renderResult(
+      { content: [{ type: "text", text: "done" }], details: augmented.details },
+      { isPartial: false, expanded: false },
+      theme,
+      { ...context, isPartial: false, isError: false }
+    );
+    assert.match(renderedLines(settled).join("\n"), /\(<1m ago\)/);
+    assert.equal(timers[0]!.delay, 60_000);
+
+    now += 60_000;
+    timers[0]!.callback();
+    assert.equal(invalidations, 1);
+    assert.match(renderedLines(settled).join("\n"), /\(1m ago\)/);
+
+    await harness.events.get("turn_end")!();
+    assert.equal(cleared.includes(timers.at(-1)), false);
+    await harness.events.get("session_shutdown")!();
+    assert.ok(cleared.includes(timers.at(-1)));
+  } finally {
+    Date.now = originalNow;
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
+});
+
+test("restored settled completion ages continue advancing after reload", async () => {
+  const harness = await registerEnabledExtension();
+  const originalNow = Date.now;
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  let now = 100_000;
+  let invalidations = 0;
+  const timers: Array<{ callback: () => void; delay: number; unref(): void }> =
+    [];
+  const cleared: unknown[] = [];
+  Date.now = () => now;
+  globalThis.setTimeout = ((callback: () => void, delay: number) => {
+    const timer = { callback, delay, unref() {} };
+    timers.push(timer);
+    return timer;
+  }) as any;
+  globalThis.clearTimeout = ((timer: unknown) => cleared.push(timer)) as any;
+  try {
+    const bash = harness.tools.get("bash");
+    const restored = bash.renderResult(
+      {
+        content: [{ type: "text", text: "done" }],
+        details: { piTidyElapsedMs: 1_000, piTidyCompletedAt: now },
+      },
+      { isPartial: false, expanded: false },
+      { bg: (_name: string, text: string) => text },
+      {
+        isPartial: false,
+        isError: false,
+        toolCallId: "restored-age",
+        args: { command: "true", reasoning: "restore prior output" },
+        invalidate() {
+          invalidations += 1;
+        },
+      }
+    );
+    assert.match(renderedLines(restored).join("\n"), /\(<1m ago\)/);
+    assert.equal(timers[0]!.delay, 60_000);
+
+    now += 60_000;
+    timers[0]!.callback();
+    assert.equal(invalidations, 1);
+    assert.match(renderedLines(restored).join("\n"), /\(1m ago\)/);
+
+    await harness.events.get("session_shutdown")!();
+    assert.ok(cleared.includes(timers.at(-1)));
+  } finally {
+    Date.now = originalNow;
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
+});
+
 test("tool results persist elapsed duration for reload", async () => {
   const handlers = new Map<string, (event: any) => Promise<any>>();
   const previous = process.env.PI_TIDY_TOOLS;
@@ -554,6 +674,7 @@ test("enabled startup preserves every optional registration", () => {
     "tool_execution_end",
     "tool_result",
     "turn_end",
+    "session_shutdown",
   ]);
   assert.deepEqual(registrations.shortcuts, ["ctrl+shift+o"]);
   assert.deepEqual(registrations.renderers, ["minimal-turn-diff"]);


### PR DESCRIPTION
## Summary

- keep settled tool completion ages advancing while they remain displayed
- refresh hydrated results after `/reload` and session resume
- coalesce all settled rows onto one session-wide minute/hour/day refresh cadence to avoid staggered transcript rerenders
- clean refresh resources up on session shutdown
- document the restored live-age contract

## Root cause

Settled rows retained the correct persisted completion timestamp, but no refresh was scheduled after they settled or were hydrated. The first correction scheduled every row at its own exact boundary; with many historical rows, those staggered callbacks caused frequent, jarring redraws. The final scheduler uses the earliest initial boundary and then refreshes all displayed ages in one shared cadence.

## Verification

- active-turn and restored-result age regressions pass
- multi-row regression proves three staggered rows produce one refresh callback per minute window, not three
- `npm test`
- `npm run check`
- `git diff --check`
- real Pi 0.80.6 TUI observations confirmed advancement through `(1m ago)` and `(5m ago)` while another tool kept the turn active
