### PR TITLE
fix(tools): coalesce age refresh redraws

### DIFF
--- a/packages/pi-tidy-tools/index.ts
+++ b/packages/pi-tidy-tools/index.ts
@@ -486,8 +486,9 @@ export default function (pi: ExtensionAPI) {
 	const pathByCallId = new Map<string, string>();
 	const startedAtByCallId = new Map<string, number>();
 	const elapsedTimerByCallId = new Map<string, ReturnType<typeof setInterval>>();
-	const ageRefreshByCallId = new Map<string, { completedAt: number; invalidate: () => void; nextAt: number }>();
+	const ageRefreshByCallId = new Map<string, { completedAt: number; invalidate: () => void }>();
 	let ageRefreshTimer: ReturnType<typeof setTimeout> | undefined;
+	let ageRefreshAt: number | undefined;
 
 	const nextAgeRefreshAt = (completedAt: number, now: number): number => {
 		const age = Math.max(0, now - completedAt);
@@ -495,32 +496,39 @@ export default function (pi: ExtensionAPI) {
 		if (age < 30 * 24 * 60 * 60_000) return completedAt + (Math.floor(age / 3_600_000) + 1) * 3_600_000;
 		return completedAt + (Math.floor(age / 86_400_000) + 1) * 86_400_000;
 	};
-	const scheduleAgeRefresh = (): void => {
+	const ageRefreshCadence = (now: number): number => {
+		let cadence = 86_400_000;
+		for (const { completedAt } of ageRefreshByCallId.values()) {
+			const age = Math.max(0, now - completedAt);
+			if (age < 24 * 60 * 60_000) return 60_000;
+			if (age < 30 * 24 * 60 * 60_000) cadence = 3_600_000;
+		}
+		return cadence;
+	};
+	const scheduleAgeRefreshAt = (next: number): void => {
+		if (ageRefreshByCallId.size === 0) return;
+		if (ageRefreshTimer && ageRefreshAt !== undefined && ageRefreshAt <= next) return;
 		if (ageRefreshTimer) clearTimeout(ageRefreshTimer);
-		if (ageRefreshByCallId.size === 0) { ageRefreshTimer = undefined; return; }
-		const now = Date.now();
-		const next = Math.min(...[...ageRefreshByCallId.values()].map(({ nextAt }) => nextAt));
+		ageRefreshAt = next;
 		ageRefreshTimer = setTimeout(() => {
 			ageRefreshTimer = undefined;
+			ageRefreshAt = undefined;
 			const refreshNow = Date.now();
-			for (const entry of ageRefreshByCallId.values()) {
-				if (entry.nextAt > refreshNow) continue;
-				entry.nextAt = nextAgeRefreshAt(entry.completedAt, refreshNow);
-				entry.invalidate();
-			}
-			scheduleAgeRefresh();
-		}, Math.max(1, next - now));
+			for (const { invalidate } of ageRefreshByCallId.values()) invalidate();
+			scheduleAgeRefreshAt(refreshNow + ageRefreshCadence(refreshNow));
+		}, Math.max(1, next - Date.now()));
 		ageRefreshTimer.unref?.();
 	};
 	const registerAgeRefresh = (id: string, completedAt: number, invalidate: () => void): void => {
 		const previous = ageRefreshByCallId.get(id);
 		const unchanged = previous?.completedAt === completedAt;
-		ageRefreshByCallId.set(id, { completedAt, invalidate, nextAt: unchanged ? previous.nextAt : nextAgeRefreshAt(completedAt, Date.now()) });
-		if (!unchanged || !ageRefreshTimer) scheduleAgeRefresh();
+		ageRefreshByCallId.set(id, { completedAt, invalidate });
+		if (!unchanged) scheduleAgeRefreshAt(nextAgeRefreshAt(completedAt, Date.now()));
 	};
 	const clearAgeRefresh = (): void => {
 		if (ageRefreshTimer) clearTimeout(ageRefreshTimer);
 		ageRefreshTimer = undefined;
+		ageRefreshAt = undefined;
 		ageRefreshByCallId.clear();
 	};
 

--- a/packages/pi-tidy-tools/test/extension.test.ts
+++ b/packages/pi-tidy-tools/test/extension.test.ts
@@ -293,6 +293,66 @@ test("restored settled completion ages continue advancing after reload", async (
   }
 });
 
+test("restored rows coalesce age refreshes into one redraw window", async () => {
+  const harness = await registerEnabledExtension();
+  const originalNow = Date.now;
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  let now = 120_000;
+  const timers: Array<{
+    callback: () => void;
+    delay: number;
+    cleared: boolean;
+    unref(): void;
+  }> = [];
+  Date.now = () => now;
+  globalThis.setTimeout = ((callback: () => void, delay: number) => {
+    const timer = { callback, delay, cleared: false, unref() {} };
+    timers.push(timer);
+    return timer;
+  }) as any;
+  globalThis.clearTimeout = ((timer: (typeof timers)[number]) => {
+    timer.cleared = true;
+  }) as any;
+  try {
+    const bash = harness.tools.get("bash");
+    for (const [index, completedAt] of [58_000, 59_000, 60_000].entries()) {
+      bash.renderResult(
+        {
+          content: [{ type: "text", text: "done" }],
+          details: { piTidyElapsedMs: 1_000, piTidyCompletedAt: completedAt },
+        },
+        { isPartial: false, expanded: false },
+        { bg: (_name: string, text: string) => text },
+        {
+          isPartial: false,
+          isError: false,
+          toolCallId: `restored-${index}`,
+          args: { command: "true", reasoning: "restore prior output" },
+          invalidate() {},
+        }
+      );
+    }
+
+    const windowEndsAt = now + 60_000;
+    let refreshCallbacks = 0;
+    while (true) {
+      const timer = [...timers].reverse().find((candidate) => !candidate.cleared);
+      if (!timer || now + timer.delay > windowEndsAt) break;
+      timer.cleared = true;
+      now += timer.delay;
+      timer.callback();
+      refreshCallbacks += 1;
+    }
+    assert.equal(refreshCallbacks, 1);
+    await harness.events.get("session_shutdown")!();
+  } finally {
+    Date.now = originalNow;
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
+});
+
 test("tool results persist elapsed duration for reload", async () => {
   const handlers = new Map<string, (event: any) => Promise<any>>();
   const previous = process.env.PI_TIDY_TOOLS;


### PR DESCRIPTION
## Summary

- coalesce settled completion-age updates onto one session-wide refresh cadence
- preserve minute/hour/day age advancement after reload and resume
- prevent transcripts with staggered historical calls from causing repeated redraws throughout each minute

## Root cause

PR #31 scheduled each settled row at its own exact age boundary. With many rows completed at different seconds, the TUI received many separate timer-driven invalidations per minute, producing visible rerender jitter.

## Verification

- regression reproduces three staggered restored rows producing 3 callbacks in one minute window before the fix
- the same scenario now produces exactly 1 callback
- active-turn and restored-session age advancement regressions still pass
- `npm test`
- `npm run check`
- `git diff --check`
