### PR TITLE
fix(pi-fff): ignore unrelated external settings symlinks

### DIFF
--- a/packages/pi-tidy-tools/pi-fff/integration.ts
+++ b/packages/pi-tidy-tools/pi-fff/integration.ts
@@ -162,23 +162,24 @@ function pathWithin(root: string, target: string): boolean {
 	return child === "" || (!child.startsWith("..") && !isAbsolute(child));
 }
 
-async function canonicalSettings(fs: PiFffLifecycleFs, candidate: string, managedRoot = dirname(candidate)): Promise<{ path: string; bytes: Buffer; mode: number } | undefined> {
+async function canonicalSettings(fs: PiFffLifecycleFs, candidate: string, managedRoot = dirname(candidate), allowOutsideManagedRoot = false): Promise<{ path: string; bytes: Buffer; mode: number; withinManagedRoot: boolean } | undefined> {
 	let link;
 	try { link = await fs.lstat(candidate); }
 	catch (error: any) { if (error?.code === "ENOENT") return undefined; throw error; }
 	if (!link.isFile() && !link.isSymbolicLink()) throw new LifecycleFailure("PIFFF_SETTINGS_DRIFT", `${candidate} is not a file`, [candidate]);
 	const [path, root] = await Promise.all([fs.realpath(candidate), fs.realpath(managedRoot)]);
-	if (!pathWithin(root, path)) throw new LifecycleFailure("PIFFF_RECOVERY_UNSAFE", `${candidate} resolves outside its managed settings scope: ${path}`, [candidate, path]);
+	const withinManagedRoot = pathWithin(root, path);
+	if (!withinManagedRoot && !allowOutsideManagedRoot) throw new LifecycleFailure("PIFFF_RECOVERY_UNSAFE", `${candidate} resolves outside its managed settings scope: ${path}`, [candidate, path]);
 	const target = await fs.stat(path);
 	if (!target.isFile()) throw new LifecycleFailure("PIFFF_SETTINGS_DRIFT", `${candidate} does not resolve to a regular file`, [candidate, path]);
-	return { path, bytes: await fs.readFile(path), mode: target.mode & 0o777 };
+	return { path, bytes: await fs.readFile(path), mode: target.mode & 0o777, withinManagedRoot };
 }
 
 async function discover(fs: PiFffLifecycleFs, cwd: string, agentDir: string): Promise<LocatedParticipant[]> {
 	const found: LocatedParticipant[] = [];
 	for (const scope of scopes) {
 		const candidate = settingsCandidate(cwd, agentDir, scope);
-		const canonical = await canonicalSettings(fs, candidate, dirname(candidate));
+		const canonical = await canonicalSettings(fs, candidate, dirname(candidate), true);
 		if (!canonical) continue;
 		const settings = parseObject(canonical.bytes, `${scope} settings`);
 		const packages = settings.packages;
@@ -188,8 +189,9 @@ async function discover(fs: PiFffLifecycleFs, cwd: string, agentDir: string): Pr
 			const matched = matchPiFffSource(sourceOf(entry));
 			return matched ? [{ index, packageSource: matched.packageProfile }] : [];
 		});
-		if (matches.length > 1) throw new LifecycleFailure("PIFFF_CONFIG_AMBIGUOUS", `${scope} settings contains both or duplicate pi-fff package identities`);
 		if (!matches.length) continue;
+		if (!canonical.withinManagedRoot) throw new LifecycleFailure("PIFFF_RECOVERY_UNSAFE", `${candidate} resolves outside its managed settings scope: ${canonical.path}`, [candidate, canonical.path]);
+		if (matches.length > 1) throw new LifecycleFailure("PIFFF_CONFIG_AMBIGUOUS", `${scope} settings contains both or duplicate pi-fff package identities`);
 		if (found.some((participant) => participant.settingsPath === canonical.path)) {
 			throw new LifecycleFailure("PIFFF_CONFIG_AMBIGUOUS", `project and user settings resolve to the same canonical file: ${canonical.path}`);
 		}

--- a/packages/pi-tidy-tools/test/pi-fff-lifecycle.test.ts
+++ b/packages/pi-tidy-tools/test/pi-fff-lifecycle.test.ts
@@ -476,13 +476,17 @@ test("settings symlinks preserve links, canonical targets, modes, and temp clean
 	} finally { await rm(f.root, { recursive: true, force: true }); }
 });
 
-test("settings symlink escapes are rejected without changing the outside target", async () => {
+test("external settings symlinks are ignored without pi-fff and rejected with it", async () => {
 	const f = await fixture();
 	try {
 		const outside = join(f.root, "outside-settings.json");
+		await writeFile(outside, JSON.stringify({ packages: ["npm:not-fff@1.0.0"] }) + "\n");
+		await symlink(outside, f.paths.project);
+		const status = await f.lifecycle().run("status", { enabled: true });
+		assert.equal(status.outcome, "status");
+		assert.deepEqual(status.participants, []);
 		const bytes = JSON.stringify({ packages: [entry("project")], sibling: true }) + "\n";
 		await writeFile(outside, bytes);
-		await symlink(outside, f.paths.project);
 		const result = await f.lifecycle().run("setup", { enabled: true, confirm: async () => true, reload: async () => {} });
 		assert.equal(result.code, "PIFFF_RECOVERY_UNSAFE");
 		assert.equal(await readFile(outside, "utf8"), bytes);


### PR DESCRIPTION
## Reported behavior

With global Pi settings managed as an external symlink:

```text
~/.pi/agent/settings.json
→ ~/projects/my-repos/agents/pi/agent/settings.json
```

Pi startup displayed this error notification:

```text
Error: /Users/iurysouza/.pi/agent/settings.json resolves outside its managed settings scope: /Users/iurysouza/projects/my-repos/agents/pi/agent/settings.json
```

Pi itself continued working. The notification came from pi-tidy-tools initializing its optional pi-fff integration. On every startup, pi-tidy-tools checked global and project settings for a pi-fff package. It applied the mutation safety boundary before checking whether pi-fff was configured, so any settings symlink outside `~/.pi/agent` looked unsafe even when the file contained no pi-fff entry and no write would occur.

## Fix

- allow read-only discovery of settings symlinks outside the managed scope
- ignore those settings when they contain no pi-fff package
- preserve `PIFFF_RECOVERY_UNSAFE` before setup or mutation when pi-fff is configured

In practice, repository-managed Pi settings no longer produce an irrelevant startup error, while the existing protection against pi-fff rewriting files outside its managed scope remains intact.

## Verification

- pi-fff lifecycle suite: 34/34 passed
- `npm run check --workspace @mobrienv/pi-tidy-tools`
- `git diff --check`