### PR TITLE
fix(pi-tidy-tools): locate running Pi under the bundled runtime (pi 0.84.3)

### DIFF
--- a/packages/pi-tidy-tools/pi-fff/adapter.ts
+++ b/packages/pi-tidy-tools/pi-fff/adapter.ts
@@ -17,6 +17,7 @@ export type { PiFffCapabilityProfile, PiFffPackageIdentity } from "./profiles.js
 export type PiFffDiagnosticCode =
 	| "PIFFF_BELOW_MINIMUM"
 	| "PIFFF_CAPABILITY_MISSING"
+	| "PIFFF_PI_ROOT_UNAVAILABLE"
 	| "PIFFF_CONFIG_MISSING"
 	| "PIFFF_CONFIG_AMBIGUOUS"
 	| "PIFFF_CONFIG_FILTER_REQUIRED"
@@ -96,6 +97,8 @@ export interface BuildPiFffPlanOptions {
 	piVersion?: string;
 	loader?: PiFffModuleLoader;
 	aliases?: PiFffLoaderAliases;
+	/** Bare-specifier Pi resolution override used by the running-Pi loader; hermetic tests stub bundled runtimes. */
+	resolvePiModule?: (specifier: string) => string;
 	conflicts?: PiFffConflictSet;
 	/** Registry integrity already available to the host; this adapter never fetches it. */
 	registryIntegrity?: string;
@@ -165,6 +168,7 @@ function diagnostic(
 	const summaries: Record<PiFffDiagnosticCode, string> = {
 		PIFFF_BELOW_MINIMUM: `pi-fff adapter inactive: minimums are Pi ${MIN_PI} and ${profile.identity} ${profile.minimum}.`,
 		PIFFF_CAPABILITY_MISSING: "pi-fff adapter inactive: a required running Pi capability is unavailable.",
+		PIFFF_PI_ROOT_UNAVAILABLE: "pi-fff adapter inactive: the running Pi installation could not be located.",
 		PIFFF_CONFIG_MISSING: "pi-fff adapter inactive: no managed pi-fff package entry is selected.",
 		PIFFF_CONFIG_AMBIGUOUS: "pi-fff adapter inactive: package identity selection is ambiguous.",
 		PIFFF_CONFIG_FILTER_REQUIRED: "pi-fff adapter inactive: pi-fff must use object form with extensions: [].",
@@ -183,6 +187,7 @@ function diagnostic(
 	const actions: Record<PiFffDiagnosticCode, string> = {
 		PIFFF_BELOW_MINIMUM: "Upgrade the below-minimum component, then /reload; this version is outside the supported range, not necessarily broken.",
 		PIFFF_CAPABILITY_MISSING: "Upgrade or reinstall Pi so the named capability is available, then /reload.",
+		PIFFF_PI_ROOT_UNAVAILABLE: "Reinstall Pi through npm or the official installer so `pi -v` runs from a package root, then /reload.",
 		PIFFF_CONFIG_MISSING: "Install pi-fff or @ff-labs/pi-fff in a managed Pi npm scope, then run /tidy pi-fff setup.",
 		PIFFF_CONFIG_AMBIGUOUS: "Keep exactly one pi-fff package identity in each settings scope, then /reload.",
 		PIFFF_CONFIG_FILTER_REQUIRED: "Run /tidy pi-fff setup to set extensions: [], then /reload.",
@@ -565,11 +570,14 @@ export async function buildPiFffRegistrationPlan(options: BuildPiFffPlanOptions)
 	let aliases = options.aliases;
 	if (!loader) {
 		try {
-			const running = createRunningPiFffLoader();
+			const running = createRunningPiFffLoader(options.resolvePiModule ? { resolveModule: options.resolvePiModule } : undefined);
 			loader = running.loader;
 			aliases ??= running.aliases;
 		} catch (error) {
-			return { ok: false, diagnostic: diagnostic("PIFFF_CAPABILITY_MISSING", piVersion, piFffVersion, `loader aliases: ${oneLine(error)}`) };
+			const code = /running Pi package root is unavailable/.test(String(error instanceof Error ? error.message : error))
+				? "PIFFF_PI_ROOT_UNAVAILABLE"
+				: "PIFFF_CAPABILITY_MISSING";
+			return { ok: false, diagnostic: diagnostic(code, piVersion, piFffVersion, `loader aliases: ${oneLine(error)}`) };
 		}
 	}
 	if (!aliases) {

--- a/packages/pi-tidy-tools/pi-fff/loader.ts
+++ b/packages/pi-tidy-tools/pi-fff/loader.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -15,6 +15,15 @@ export interface PiFffModuleLoader {
 	load(entryPath: string, aliases: PiFffLoaderAliases): Promise<unknown>;
 }
 
+export interface ResolveRunningPiAliasesOptions {
+	/** Bare-specifier resolution used only when the live process entry is not Pi itself; hermetic tests stub bundled runtimes. */
+	readonly resolveModule?: (specifier: string) => string;
+}
+
+const PI_PACKAGE_NAME = "@earendil-works/pi-coding-agent";
+
+const defaultResolveModule = (specifier: string): string => import.meta.resolve(specifier);
+
 function findPackageRoot(entry: string): string {
 	let current = dirname(entry);
 	while (current !== dirname(current)) {
@@ -24,22 +33,59 @@ function findPackageRoot(entry: string): string {
 	throw new Error("running Pi package root is unavailable");
 }
 
-/** Resolve aliases from the concrete Pi installation that loaded tidy. */
-export function resolveRunningPiAliases(): { aliases: PiFffLoaderAliases; jitiEntry: string } {
-	let piRoot: string | undefined;
+function readManifestAt(root: string): any {
+	return JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+}
+
+function piRootFromEntry(entry: string): string | undefined {
 	try {
-		const candidate = findPackageRoot(resolve(process.argv[1] ?? ""));
-		const manifest = JSON.parse(readFileSync(join(candidate, "package.json"), "utf8"));
-		if (manifest?.name === "@earendil-works/pi-coding-agent") piRoot = candidate;
+		const candidate = findPackageRoot(entry);
+		return readManifestAt(candidate)?.name === PI_PACKAGE_NAME ? candidate : undefined;
 	} catch {
-		// Tests and SDK hosts may not have Pi as argv[1]; use normal ESM identity.
+		return undefined;
 	}
-	const resolvedCodingAgent = fileURLToPath(import.meta.resolve("@earendil-works/pi-coding-agent"));
-	piRoot ??= findPackageRoot(resolvedCodingAgent);
-	const piManifest = JSON.parse(readFileSync(join(piRoot, "package.json"), "utf8"));
+}
+
+function safeRealpath(path: string): string {
+	try {
+		return realpathSync(path);
+	} catch {
+		return path;
+	}
+}
+
+function piRootFromProcessEntry(): string | undefined {
+	const entry = process.argv[1];
+	if (!entry) return undefined;
+	// npm links the Pi CLI bin outside the package tree; probe both the link and its target.
+	for (const candidate of [resolve(entry), safeRealpath(resolve(entry))]) {
+		const root = piRootFromEntry(candidate);
+		if (root) return root;
+	}
+	return undefined;
+}
+
+/** Resolve aliases from the concrete Pi installation that loaded tidy. */
+export function resolveRunningPiAliases(options: ResolveRunningPiAliasesOptions = {}): { aliases: PiFffLoaderAliases; jitiEntry: string } {
+	let piRoot = piRootFromProcessEntry();
+	let resolvedCodingAgent: string | undefined;
+	if (!piRoot) {
+		// Tests and SDK hosts may not have Pi as argv[1]; use normal ESM identity.
+		// Bundled Pi runtimes (0.84.3+) resolve no bare specifier from tidy's own directory.
+		try {
+			resolvedCodingAgent = fileURLToPath((options.resolveModule ?? defaultResolveModule)(PI_PACKAGE_NAME));
+			piRoot = piRootFromEntry(resolvedCodingAgent);
+		} catch {
+			// Unresolvable from this directory; the fail-closed check below reports it.
+		}
+	}
+	if (!piRoot) throw new Error(`running Pi package root is unavailable: ${PI_PACKAGE_NAME} was not reachable from the process entry or module resolution`);
+	const piManifest = readManifestAt(piRoot);
 	const codingExport = piManifest?.exports?.["."]?.import;
 	const codingTarget = typeof codingExport === "string" ? codingExport : codingExport?.default;
-	const codingAgent = typeof codingTarget === "string" ? resolve(piRoot, codingTarget) : resolvedCodingAgent;
+	const codingFallback = resolvedCodingAgent
+		?? (typeof piManifest?.main === "string" ? resolve(piRoot, piManifest.main) : join(piRoot, "index.js"));
+	const codingAgent = typeof codingTarget === "string" ? resolve(piRoot, codingTarget) : codingFallback;
 	const piRequire = createRequire(join(piRoot, "package.json"));
 	const tui = piRequire.resolve("@earendil-works/pi-tui");
 	const typebox = piRequire.resolve("typebox");
@@ -67,8 +113,8 @@ export function resolveRunningPiAliases(): { aliases: PiFffLoaderAliases; jitiEn
 }
 
 /** Build an uncached loader using the running Pi installation's Jiti. */
-export function createRunningPiFffLoader(): { loader: PiFffModuleLoader; aliases: PiFffLoaderAliases } {
-	const { aliases, jitiEntry } = resolveRunningPiAliases();
+export function createRunningPiFffLoader(options: ResolveRunningPiAliasesOptions = {}): { loader: PiFffModuleLoader; aliases: PiFffLoaderAliases } {
+	const { aliases, jitiEntry } = resolveRunningPiAliases(options);
 	return {
 		aliases,
 		loader: {

--- a/packages/pi-tidy-tools/test/pi-fff-adapter.test.ts
+++ b/packages/pi-tidy-tools/test/pi-fff-adapter.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 import {
@@ -584,6 +584,70 @@ test("running Pi resolution handles host manifests and rejects missing Jiti capa
 	} finally {
 		process.argv[1] = previousArgv;
 		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("bundled Pi runtime resolves aliases from the process entry when the bare specifier is unresolvable", async () => {
+	const root = await realpath(await mkdtemp(join(tmpdir(), "tidy-pi-fff-bundled-")));
+	const piRoot = join(root, "node_modules", "@earendil-works", "pi-coding-agent");
+	const jitiRoot = join(piRoot, "node_modules", "jiti");
+	const previousArgv = process.argv[1];
+	const unresolvable = (): string => { throw new Error("Cannot find module '@earendil-works/pi-coding-agent'"); };
+	try {
+		await mkdir(join(piRoot, "dist", "bundle"), { recursive: true });
+		await mkdir(jitiRoot, { recursive: true });
+		await mkdir(join(piRoot, "node_modules", "@earendil-works", "pi-tui"), { recursive: true });
+		await mkdir(join(piRoot, "node_modules", "typebox"), { recursive: true });
+		await writeFile(join(piRoot, "dist", "index.js"), "export {};\n");
+		await writeFile(join(piRoot, "dist", "bundle", "cli.js"), "#!/usr/bin/env node\n");
+		await writeFile(join(piRoot, "package.json"), JSON.stringify({
+			name: "@earendil-works/pi-coding-agent", version: "0.84.3",
+			exports: { ".": { import: "./dist/index.js" } },
+		}));
+		await writeFile(join(piRoot, "node_modules", "@earendil-works", "pi-tui", "package.json"), JSON.stringify({ name: "@earendil-works/pi-tui", main: "index.js" }));
+		await writeFile(join(piRoot, "node_modules", "@earendil-works", "pi-tui", "index.js"), "export {};\n");
+		await writeFile(join(piRoot, "node_modules", "typebox", "package.json"), JSON.stringify({ name: "typebox", main: "index.js" }));
+		for (const file of ["index.js", "compile.js", "value.js"]) await writeFile(join(piRoot, "node_modules", "typebox", file), "export {};\n");
+		await writeFile(join(jitiRoot, "package.json"), JSON.stringify({
+			name: "jiti", exports: { "./package.json": "./package.json", "./static": { import: "./static.mjs" } },
+		}));
+		await writeFile(join(jitiRoot, "static.mjs"), "export const unavailable = true;\n");
+
+		process.argv[1] = join(piRoot, "dist", "bundle", "cli.js");
+		const direct = resolveRunningPiAliases({ resolveModule: unresolvable });
+		assert.equal(direct.aliases.codingAgent, join(piRoot, "dist", "index.js"));
+		assert.equal(direct.aliases["@earendil-works/pi-coding-agent"], direct.aliases.codingAgent);
+		assert.equal(direct.jitiEntry, join(jitiRoot, "static.mjs"));
+
+		const binDir = join(root, "bin");
+		await mkdir(binDir, { recursive: true });
+		await symlink(join(piRoot, "dist", "bundle", "cli.js"), join(binDir, "pi"));
+		process.argv[1] = join(binDir, "pi");
+		const linked = resolveRunningPiAliases({ resolveModule: unresolvable });
+		assert.equal(linked.aliases.codingAgent, join(piRoot, "dist", "index.js"));
+		assert.equal(linked.jitiEntry, join(jitiRoot, "static.mjs"));
+	} finally {
+		process.argv[1] = previousArgv;
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("unlocatable running Pi fails closed with PIFFF_PI_ROOT_UNAVAILABLE", async () => {
+	const root = await realpath(await mkdtemp(join(tmpdir(), "tidy-pi-fff-orphan-")));
+	const f = await fixture({ userEntry: filtered() });
+	const previousArgv = process.argv[1];
+	const unresolvable = (): string => { throw new Error("Cannot find module '@earendil-works/pi-coding-agent'"); };
+	try {
+		await writeFile(join(root, "orphan-run.js"), "// not inside any Pi package\n");
+		process.argv[1] = join(root, "orphan-run.js");
+		assert.throws(() => resolveRunningPiAliases({ resolveModule: unresolvable }), /running Pi package root is unavailable/);
+		const result = await buildPiFffRegistrationPlan({ cwd: f.cwd, agentDir: f.agentDir, piVersion: "0.84.3", api: apiRecorder().api, resolvePiModule: unresolvable });
+		expectCode(result, "PIFFF_PI_ROOT_UNAVAILABLE");
+		assert.match(!result.ok ? result.diagnostic.summary : "", /running Pi installation could not be located/);
+	} finally {
+		process.argv[1] = previousArgv;
+		await rm(root, { recursive: true, force: true });
+		await rm(f.root, { recursive: true, force: true });
 	}
 });
 


### PR DESCRIPTION
## Summary

`/tidy pi-fff setup` failed preflight on pi 0.84.3 with `PIFFF_PREFLIGHT_FAILED: pi-fff adapter inactive`, where the diagnostic detail held the real error: `loader aliases: Cannot find module '@earendil-works/pi-coding-agent'`.

Verified root cause (two compounding defects in `resolveRunningPiAliases()`):

1. `import.meta.resolve("@earendil-works/pi-coding-agent")` ran **unconditionally** — when it threw under the bundled runtime (pi 0.84.3 loads jiti only for extensions; no `@earendil-works` package exists in tidy's own resolution scope), the whole function died even when the `argv[1]` probe had already located the Pi root.
2. The `argv[1]` probe never dereferenced npm's bin **symlink** (`/usr/local/bin/pi` → `…/pi-coding-agent/dist/bundle/cli.js`), so it silently failed on the most common install shape.

## Changes

- `pi-fff/loader.ts`: derive the Pi package root from the process entry first, probing both the raw `argv[1]` path and its realpath (bin symlink). `import.meta.resolve` is now a guarded fallback for tests/SDK hosts; its failure no longer discards an already-located root. Failure is fail-closed.
- `pi-fff/adapter.ts`: new `PIFFF_PI_ROOT_UNAVAILABLE` diagnostic code (summary + action) so a genuinely unlocatable Pi root no longer masquerades as `PIFFF_CAPABILITY_MISSING`; mapped by matching the loader's fail-closed error. `BuildPiFffPlanOptions.resolvePiModule` allows hermetic stubbing of bare-specifier resolution.
- `test/pi-fff-adapter.test.ts`: two regression tests — bundled-runtime resolution through the process entry incl. a bin symlink with the bare specifier unresolvable, and the fail-closed `PIFFF_PI_ROOT_UNAVAILABLE` path.

Legacy non-bundled installs are unaffected: when the process entry is not Pi, resolution falls back to `import.meta.resolve` exactly as before.

## Verification

**Repo suite** (clean `HOME`; the machine's real `~/.pi/agent/pi-tidy-tools.json` has `"icons": false` which 5 extension tests otherwise pick up — same 5 fail on pristine `origin/main`, purely environmental):

```
@mobrienv/pi-tidy-core      tests 12  pass 12
@mobrienv/pi-tidy-footer    tests 30  pass 30
@mobrienv/pi-tidy-memory    tests 91  pass 91
@mobrienv/pi-tidy-subagents tests 152 pass 149 (3 skipped)
@mobrienv/pi-tidy-tools     tests 200 pass 200   ← includes 2 new regression tests
scripts (embed/publish/pack) tests 5   pass 5
```
Root `npm test` exit 0. `npm run check` (bundle + `tsc --noEmit`) exit 0.

**Smoke against real pi 0.84.3** (npm tarball, bin-symlink `argv[1]`, tidy packed into an agent npm tree where the bare specifier cannot resolve — the exact #64 topology):

```
== pi-tidy-tools #64 smoke: real pi 0.84.3, bin symlink argv ==
PASS  old loader reproduces #64: Cannot find module '@earendil-works/pi-coding-agent'
PASS  new loader codingAgent: …/pi-coding-agent/dist/index.js
PASS  new loader jitiEntry: …/pi-coding-agent/node_modules/jiti/lib/jiti-static.mjs
PASS  new loader tui: …/pi-coding-agent/node_modules/@earendil-works/pi-tui/dist/index.js
PASS  new loader typebox identity: true
PASS  probe factory via real jiti: VERSION=0.84.3 sameType=true
SMOKE OK
```

## Upstream

`@ff-labs/pi-fff` latest is still 0.10.5 (the reporter's version) — no upstream fix exists; the broken code is tidy's own integration shim, so this patch is in-repo by construction.

Closes #64