### PR TITLE
fix: add path validation in server.ts

### DIFF
--- a/packages/pi-tidy-bots/src/server.ts
+++ b/packages/pi-tidy-bots/src/server.ts
@@ -8,7 +8,7 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import { Hono } from "hono";
 import {
   botDisclosure,
@@ -73,10 +73,11 @@ export function safeAppAssetPath(
   root: string = APP_DIR
 ): string | undefined {
   const relative = urlPath.replace(/^\/app\/?/, "");
+  if (relative.includes("..")) return undefined;
   // Directory mount points serve the entry document, matching `app.get("/")`
   // behavior for the vanilla console. Files under /app/ pass through.
   const resolved = join(root, relative || "index.html");
-  if (!resolved.startsWith(root)) return undefined;
+  if (resolved !== root && !resolved.startsWith(root + sep)) return undefined;
   return resolved;
 }
 


### PR DESCRIPTION
## Summary
Fix high severity security issue in `packages/pi-tidy-bots/src/server.ts`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `packages/pi-tidy-bots/src/server.ts:83` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-22 |

**Description**: The /app/* endpoint serves static files using a path traversal protection mechanism that is insufficient. The safeAppAssetPath function attempts to prevent directory traversal by checking if the resolved path starts with the root directory, but this check occurs after path normalization by join(). The function does not validate or reject path traversal sequences (../, ..\) in the raw URL path before processing, allowing attackers to potentially escape the intended directory through edge cases in path normalization behavior.

## Evidence

**Exploitation scenario**: An attacker can send a crafted HTTP request to escape the APP_DIR directory and read arbitrary files.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a private Node.js application (not published to npm). Vulnerabilities affect this application's own runtime only.

## Changes
- `packages/pi-tidy-bots/src/server.ts`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-001 scanner=multi_agent_ai -->
