### PR TITLE
fix(pi-tidy-bots): reject path traversal in safeAppAssetPath

### DIFF
--- a/packages/pi-tidy-bots/src/server.ts
+++ b/packages/pi-tidy-bots/src/server.ts
@@ -8,7 +8,7 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import { Hono } from "hono";
 import {
   botDisclosure,
@@ -73,10 +73,11 @@ export function safeAppAssetPath(
   root: string = APP_DIR
 ): string | undefined {
   const relative = urlPath.replace(/^\/app\/?/, "");
+  if (relative.includes("..")) return undefined;
   // Directory mount points serve the entry document, matching `app.get("/")`
   // behavior for the vanilla console. Files under /app/ pass through.
   const resolved = join(root, relative || "index.html");
-  if (!resolved.startsWith(root)) return undefined;
+  if (resolved !== root && !resolved.startsWith(root + sep)) return undefined;
   return resolved;
 }
 

--- a/packages/pi-tidy-bots/test/static-assets.test.ts
+++ b/packages/pi-tidy-bots/test/static-assets.test.ts
@@ -72,6 +72,17 @@ test("safeAppAssetPath mounts under the root and refuses traversal", () => {
     "bare mount serves the entry document"
   );
   assert.equal(safeAppAssetPath("/app/../secrets.txt", root), undefined);
+  // Prefix bypass: join("/srv/app", "../app-evil/x") === "/srv/app-evil/x",
+  // which startsWith("/srv/app") but is outside the mount (CWE-22).
+  assert.equal(
+    safeAppAssetPath("/app/../app-evil/secrets.txt", root),
+    undefined
+  );
+  assert.equal(
+    safeAppAssetPath("/app/foo/../../../etc/passwd", root),
+    undefined
+  );
+  assert.equal(safeAppAssetPath("/app/..\\secrets.txt", root), undefined);
 });
 
 test("isPublicAssetPath bypasses auth for asset trees only", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Recreates fork PR #67 (OrbisAI CWE-22 autofix) from `mikeyobrien` against current `main` (`d6be0d4`), with unit tests that fail on the remaining traversal and pass after the fix.

## Verdict

Still needed. Current `main` already has `safeAppAssetPath` and one `../secrets.txt` test, but the `startsWith(root)` check still accepts sibling prefixes after `join()` normalizes `..`.

Evidence on `main` at `packages/pi-tidy-bots/src/server.ts` (blob `5aabe026481f9b8723fc2f17d03c568f0680b49b`, lines 71–80):

```ts
const resolved = join(root, relative || "index.html");
if (!resolved.startsWith(root)) return undefined;
```

`join("/srv/app", "../app-evil/secrets.txt")` → `/srv/app-evil/secrets.txt`, and `"/srv/app-evil/secrets.txt".startsWith("/srv/app")` is `true`.

#67's `+3/-2` patch against stale base `08385aa` is the right shape (reject raw `..`, require `root + sep`). This PR applies that plus tests.

## Changes

- `packages/pi-tidy-bots/src/server.ts` — reject `..` in the raw relative path; bound the resolved path with `root + sep`
- `packages/pi-tidy-bots/test/static-assets.test.ts` — sibling-prefix, nested `../`, and `..\` cases

## Proof

**Fail on current `main` implementation (before this commit):**

```bash
# added the three new asserts, left server.ts unchanged
node --import tsx --test packages/pi-tidy-bots/test/static-assets.test.ts
```

Result: **FAIL** `safeAppAssetPath mounts under the root and refuses traversal`

```
Expected values to be strictly equal:
+ '/srv/app-evil/secrets.txt'
- undefined
```

**Pass after the fix (`7ff433b`):**

```bash
node --import tsx --test packages/pi-tidy-bots/test/static-assets.test.ts
# tests 4, pass 4, fail 0

cd packages/pi-tidy-bots && npm run check
# tsc --noEmit exit 0

# remaining package tests, excluding two pre-existing flakes
# (compaction.test.ts model-switch waitFor; orphans.test.ts "orphan spawned")
node --import tsx --test $(ls test/*.test.ts | grep -v -E 'compaction|orphans')
# tests 186, pass 185, fail 0, skipped 1

cd ../.. && npm run check
# all workspaces tsc --noEmit exit 0
```

Result: **PASS**.

Repo-root `npm test` (husky pre-commit) hit two pre-existing load/env failures unrelated to this file: `compaction.test.ts` “model switch recomputes fill…” (`waitFor` timeout) and `orphans.test.ts` “orphan spawned”. Those tests do not import `safeAppAssetPath`. Not in scope; no #68 work.

## Out of scope

- No prod `:4317`
- No Hermes
- No #68 work

Supersedes https://github.com/mikeyobrien/pi-tidy-tools/pull/67 (closed; fork `anupamme/pi-tidy-tools`, stale since 2026-09-03).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a43f3723-a1a9-4050-9e60-6c20f64474c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a43f3723-a1a9-4050-9e60-6c20f64474c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

