### PR TITLE
fix(pi-tidy-bots): Hermes reload continuity across SessionDB stamps

### DIFF
--- a/packages/pi-tidy-bots/backends/hermes/history.py
+++ b/packages/pi-tidy-bots/backends/hermes/history.py
@@ -30,12 +30,35 @@ _ACCOUNTING_ROW_FIELDS = frozenset((
     "reasoning_tokens", "api_call_count", "estimated_cost_usd", "actual_cost_usd",
     "cost_status", "cost_source", "pricing_version",
 ))
+# Pinned Hermes 0.20.5 SessionDB stamps load-time bookkeeping onto every
+# decoded message (_db_persisted, _row_id, timestamp). Live ACP history after
+# a turn is result["messages"] without those keys. Treating them as
+# conversation identity left every first-turn checkpoint unavailable, so
+# reload failed as session_open:native_startup_history / continuity_unverified.
+_PERSISTENCE_BOOKKEEPING_KEYS = frozenset((
+    "_db_persisted", "_row_id", "_compressed_summary", "timestamp",
+))
 
 
 def _stable_session_row(row):
     if not isinstance(row, dict):
         raise HistoryUnavailable()
     return {key: value for key, value in row.items() if key not in _ACCOUNTING_ROW_FIELDS}
+
+
+def _conversation_identity(messages):
+    if not isinstance(messages, list):
+        raise HistoryUnavailable()
+    identity = []
+    for message in messages:
+        if not isinstance(message, dict):
+            raise HistoryUnavailable()
+        identity.append({
+            key: value for key, value in message.items()
+            if key not in _PERSISTENCE_BOOKKEEPING_KEYS
+            and not (isinstance(key, str) and key.startswith("_"))
+        })
+    return identity
 
 
 def history_checkpoint(manager, state):
@@ -52,7 +75,7 @@ def history_checkpoint(manager, state):
                 or state.queued_prompts or not isinstance(state.history, list)):
             raise HistoryUnavailable()
         cwd = str(Path(state.cwd).resolve(strict=True))
-        live_digest = _digest(state.history)
+        live_digest = _digest(_conversation_identity(state.history))
         # Do not call the lazy getter: it can create a database while proving
         # persistence. Only inspect the instance native saving already opened.
         db = getattr(manager, "_db_instance", None)
@@ -74,13 +97,15 @@ def history_checkpoint(manager, state):
         persisted = db.get_messages_as_conversation(sid, repair_alternation=False)
         restored = db.get_messages_as_conversation(sid, repair_alternation=True)
         if (not isinstance(persisted, list) or not isinstance(restored, list)
-                or _digest(persisted) != live_digest or _digest(restored) != live_digest):
+                or _digest(_conversation_identity(persisted)) != live_digest
+                or _digest(_conversation_identity(restored)) != live_digest):
             raise HistoryUnavailable()
         # Refuse a torn metadata/history observation instead of accepting one
         # successful read as proof of a stable persisted session.
         if (_digest(_stable_session_row(db.get_session(sid))) != _digest(_stable_session_row(row))
-                or _digest(db.get_messages_as_conversation(sid, repair_alternation=False)) != live_digest
-                or _digest(state.history) != live_digest):
+                or _digest(_conversation_identity(
+                    db.get_messages_as_conversation(sid, repair_alternation=False))) != live_digest
+                or _digest(_conversation_identity(state.history)) != live_digest):
             raise HistoryUnavailable()
         return {"version": 1, "sessionId": sid, "messageCount": len(persisted),
                 "historyDigest": live_digest, "metadataDigest": _digest(metadata),

--- a/packages/pi-tidy-bots/test/fixtures/gateway-application/backend.mjs
+++ b/packages/pi-tidy-bots/test/fixtures/gateway-application/backend.mjs
@@ -364,9 +364,12 @@ input.on("line", (line) => {
           maxMediaBytes: p.config.artifacts ? 524288 : 0,
         },
         sessions: {
-          load: p.config.discovery === true,
+          load: p.config.discovery === true || p.config.sessionsLoad === true,
           import: false,
-          continuity: p.config.discovery === true ? "verified" : "unverified",
+          continuity:
+            p.config.discovery === true || p.config.sessionsLoad === true
+              ? "verified"
+              : "unverified",
         },
         output: { text: "snapshots", tools: true, usage: "unknown" },
         operations: {
@@ -405,6 +408,11 @@ input.on("line", (line) => {
     record({ method: "session.open", ...p });
     if (typeof init.config?.openError === "string")
       return respondError(message, init.config.openError);
+    if (
+      p.mode === "load" &&
+      typeof init.config?.openLoadError === "string"
+    )
+      return respondError(message, init.config.openLoadError);
     if (init.config?.openStatus === "creation_unknown")
       return respond(message, { status: "creation_unknown" });
     const nativeReferencePath = join(dir, "native-reference");

--- a/packages/pi-tidy-bots/test/fixtures/hermes-native/fixture.py
+++ b/packages/pi-tidy-bots/test/fixtures/hermes-native/fixture.py
@@ -70,7 +70,10 @@ class FakeHistoryDB:
         if config().get("historyReadError"):
             raise RuntimeError("private database failure")
         value = json.loads((profile() / "state.db").read_text())
-        return value["messages"] if value["row"]["id"] == sid else []
+        messages = value["messages"] if value["row"]["id"] == sid else []
+        # Pinned Hermes SessionDB stamps load-time bookkeeping onto every
+        # decoded row. Live ACP history after a turn does not carry these keys.
+        return [{**message, "_db_persisted": True, "timestamp": 1.0} for message in messages]
 
     def save(self, state):
         (profile() / "state.db").write_text(json.dumps({"row": {"id":state.session_id, "source":"acp",

--- a/packages/pi-tidy-bots/test/gateway-application.test.ts
+++ b/packages/pi-tidy-bots/test/gateway-application.test.ts
@@ -99,7 +99,9 @@ async function fixture(
         artifacts: { type: "boolean" },
         settings: { type: "boolean" },
         openError: { type: "string" },
+        openLoadError: { type: "string" },
         openStatus: { type: "string" },
+        sessionsLoad: { type: "boolean" },
       },
       additionalProperties: false,
     })
@@ -1850,6 +1852,62 @@ test("session-open RPC errors retain unknown state and expose only a typed diagn
       (await f.request(handle, "/api/bots/fixture/operations/open:ignored"))
         .status,
       404
+    );
+  } finally {
+    await f.cleanup();
+  }
+});
+
+test("reload history failure isolates as continuity_unverified with session_open:native_startup_history", async () => {
+  const f = await fixture();
+  const faults: PluginFaultObservation[] = [];
+  try {
+    await writeFile(
+      join(f.dir, "bots.toml"),
+      f.manifest + "[bot.backend_config]\nsessionsLoad = true\n"
+    );
+    const first = await f.start();
+    const binding = await f.binding(first);
+    const admitted = await f.submit(
+      first,
+      binding,
+      "before-reload",
+      "initial turn"
+    );
+    assert.equal(admitted.status, 202);
+    await waitFor(
+      () => f.inspect(first, "before-reload"),
+      (receipt) => receipt.execution === "ended"
+    );
+    await first.stop();
+    await writeFile(
+      join(f.dir, "bots.toml"),
+      f.manifest +
+        "[bot.backend_config]\nsessionsLoad = true\nopenLoadError = \"native_startup_history\"\n"
+    );
+    const handle = await f.start({
+      onPluginFault: (fault) => faults.push(fault),
+    });
+    await waitFor(
+      async () => faults,
+      (items) =>
+        items.some((item) => item.code === "session_open:native_startup_history")
+    );
+    const roster = await f.request(handle, "/api/fleet");
+    assert.equal(roster.body.bots[0].gatewayStatus, "continuity_unverified");
+    assert.equal(roster.body.bots[0].online, false);
+    const later = await f.submit(
+      handle,
+      binding,
+      "after-reload",
+      "must be rejected while continuity is unverified"
+    );
+    assert.equal(later.status, 503);
+    assert.equal(later.body.error, "session_unavailable");
+    assert.equal(
+      faults.filter((item) => item.code === "session_open:native_startup_history")
+        .length,
+      1
     );
   } finally {
     await f.cleanup();

--- a/packages/pi-tidy-bots/test/gateway-application.test.ts
+++ b/packages/pi-tidy-bots/test/gateway-application.test.ts
@@ -1862,9 +1862,12 @@ test("reload history failure isolates as continuity_unverified with session_open
   const f = await fixture();
   const faults: PluginFaultObservation[] = [];
   try {
+    // Keep backend_config identical across restart: a policy-revision change
+    // is binding_conflict, not the continuity fault this cell isolates.
     await writeFile(
       join(f.dir, "bots.toml"),
-      f.manifest + "[bot.backend_config]\nsessionsLoad = true\n"
+      f.manifest +
+        '[bot.backend_config]\nsessionsLoad = true\nopenLoadError = "native_startup_history"\n'
     );
     const first = await f.start();
     const binding = await f.binding(first);
@@ -1880,18 +1883,15 @@ test("reload history failure isolates as continuity_unverified with session_open
       (receipt) => receipt.execution === "ended"
     );
     await first.stop();
-    await writeFile(
-      join(f.dir, "bots.toml"),
-      f.manifest +
-        "[bot.backend_config]\nsessionsLoad = true\nopenLoadError = \"native_startup_history\"\n"
-    );
     const handle = await f.start({
       onPluginFault: (fault) => faults.push(fault),
     });
     await waitFor(
       async () => faults,
       (items) =>
-        items.some((item) => item.code === "session_open:native_startup_history")
+        items.some(
+          (item) => item.code === "session_open:native_startup_history"
+        )
     );
     const roster = await f.request(handle, "/api/fleet");
     assert.equal(roster.body.bots[0].gatewayStatus, "continuity_unverified");
@@ -1905,8 +1905,9 @@ test("reload history failure isolates as continuity_unverified with session_open
     assert.equal(later.status, 503);
     assert.equal(later.body.error, "session_unavailable");
     assert.equal(
-      faults.filter((item) => item.code === "session_open:native_startup_history")
-        .length,
+      faults.filter(
+        (item) => item.code === "session_open:native_startup_history"
+      ).length,
       1
     );
   } finally {

--- a/packages/pi-tidy-bots/test/hermes-history.test.ts
+++ b/packages/pi-tidy-bots/test/hermes-history.test.ts
@@ -19,5 +19,5 @@ test("Hermes history proof rejects incomplete, repaired and rotated persistence"
     { encoding: "utf8", timeout: 10000 }
   );
   assert.equal(result.status, 0, result.stderr);
-  assert.match(result.stderr, /Ran 11 tests/);
+  assert.match(result.stderr, /Ran 12 tests/);
 });

--- a/packages/pi-tidy-bots/test/hermes-session.test.ts
+++ b/packages/pi-tidy-bots/test/hermes-session.test.ts
@@ -46,6 +46,37 @@ for (const stage of ["initialize", "opened", "complete"]) {
   });
 }
 
+test("guarded history startup failure on load exposes native_startup_history", async (t) => {
+  const f = fixture(
+    t,
+    (request, send) => {
+      if (request.method !== "session/load") return;
+      send({
+        jsonrpc: "2.0",
+        method: "_tidy/startup_failure",
+        params: { stage: "history" },
+      });
+      send({
+        jsonrpc: "2.0",
+        id: request.id,
+        error: { code: -32000, message: "private native detail" },
+      });
+    },
+    { loadSession: true, newSessionResponse: false }
+  );
+  await assert.rejects(f.session.open("/disposable", undefined, "retained-one"), {
+    code: "native_startup_history",
+  });
+  assert.equal(
+    f.calls.filter((call) => call.method === "session/load").length,
+    1
+  );
+  assert.equal(
+    JSON.stringify(f.calls).includes("private native detail"),
+    false
+  );
+});
+
 test("guarded startup failure exposes only its allowlisted stage", async (t) => {
   const f = fixture(
     t,
@@ -144,6 +175,7 @@ function fixture(
     fleetProof?: { initialize?: boolean; opened?: boolean };
     nativeImages?: boolean;
     guardVersion?: number;
+    loadSession?: boolean;
     newSessionResponse?: boolean;
   } = {}
 ) {
@@ -165,7 +197,7 @@ function fixture(
           protocolVersion: 1,
           agentInfo: { name: "hermes-agent", version: "0.20.5" },
           agentCapabilities: {
-            loadSession: false,
+            loadSession: options.loadSession === true,
             promptCapabilities: { image: options.nativeImages ?? true },
           },
           _meta: {
@@ -174,6 +206,9 @@ function fixture(
               approvalPolicy: "ask",
               environment: "explicit",
               ownedWorkers: "local-pipe-v1",
+              ...(options.loadSession
+                ? { historyLoad: "checkpoint-v1" }
+                : {}),
               ...(options.fleetProof?.initialize
                 ? { fleetTools: "native-mcp-v1" }
                 : {}),

--- a/packages/pi-tidy-bots/test/hermes_history_test.py
+++ b/packages/pi-tidy-bots/test/hermes_history_test.py
@@ -100,6 +100,19 @@ class HistoryTests(unittest.TestCase):
         self.db.get_session = changing
         self.unavailable()
 
+    def test_db_persistence_markers_are_not_conversation_identity(self):
+        original = self.db.get_messages_as_conversation
+
+        def stamped(sid, *, repair_alternation):
+            return [{**message, "_db_persisted": True, "_row_id": 17, "timestamp": 1.0}
+                    for message in original(sid, repair_alternation=repair_alternation)]
+
+        self.db.get_messages_as_conversation = stamped
+        checkpoint = history.history_checkpoint(self.manager, self.state)
+        self.assertEqual(checkpoint["messageCount"], 2)
+        self.assertNotIn("_db_persisted", json.dumps(checkpoint))
+        self.assertEqual(history.verify_history_checkpoint(self.manager, self.state, checkpoint), checkpoint)
+
     def test_accounting_flush_between_row_reads_preserves_exact_history(self):
         original = self.db.get_session
         count = 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Offline diagnosis of the Hermes cap-2 reload 503 (`session_open:native_startup_history` / `continuity_unverified`). No live Hermes, no prod `:4317` writes, no second smoke.

Rebased onto current `codex/backend-gateway` tip `ee73ac2` (includes #68 @ `e39f63c` and #72). No conflicts.

## Emit path

1. Guarded native `session/load` fails the history stage and emits `_tidy/startup_failure` `{stage:"history"}` (`backends/hermes/native_guard.py`).
2. `HermesSession.open` remaps that to `ProtocolError("native_startup_history")` (`backends/hermes/session.ts`).
3. Gateway `observeOpenFailure` emits `session_open:native_startup_history` and sets `bot.fault = "continuity_unverified"` (`src/gateway/application.ts`).
4. Later `/message` is `503 {"error":"session_unavailable"}`.

## Root cause

Pinned Hermes 0.20.5 `SessionDB.get_messages_as_conversation` stamps every decoded row with `_db_persisted` (and `timestamp` / `_row_id`). Live ACP history after a turn is `result["messages"]` without those keys.

`history_checkpoint` required a byte-identical digest of live vs both DB views. First-turn proof always failed, no checkpoint file was saved, and reload `history_store.load` failed as stage `history`.

`ed32dad` ignored accounting fields on `get_session()` flush. That was real, but not this gap.

## Fix

Digest conversation identity after stripping SessionDB load-time bookkeeping. Content, roles, repair mismatch, and lineage rotation still fail closed. Reload test keeps the same `backend_config` across restart (`openLoadError` mid-flight is `binding_conflict`).

## Offline proof (after rebase)

Runtime: Node **26.7.0** (SQLite 3.53.4).

| Command | Result |
| --- | --- |
| `python3 -I -B packages/pi-tidy-bots/test/hermes_history_test.py` | **PASS** 12 |
| Same, identity strip removed (not committed) | **FAIL** `HistoryUnavailable` on DB stamps |
| `hermes-history.test.ts` | **PASS** |
| `hermes-session.test.ts` load + stage `history` | **PASS** `native_startup_history` |
| `gateway-application.test.ts` reload isolate | **PASS** fault + 503 |
| `hermes-runtime.test.ts` cold restore (stamped FakeHistoryDB) | **PASS** 6 |
| `npm run check` (repo root) | **PASS** |

Commits on this PR: `bc1539b`, `ca6dbe4`.

Out of scope: new_context #68 behavior, Flutter, live Hermes.

Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-975e3002-d902-41e4-9db3-3cebbe64c829?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-975e3002-d902-41e4-9db3-3cebbe64c829&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

