### PR TITLE
fix(pi-tidy-bots): take over dead-pid fleet lock on restart (178)

### DIFF
--- a/packages/pi-tidy-bots/src/cli.ts
+++ b/packages/pi-tidy-bots/src/cli.ts
@@ -22,6 +22,7 @@ import {
 import { DAEMON_REVISION } from "./revision.ts";
 import { loadFleetConfig, ConfigError, NAME_PATTERN } from "./config.ts";
 import { createRotatingLogWriter } from "./logs.ts";
+import { isFleetLockFree } from "./lock.ts";
 import {
   closestFlag,
   CliError,
@@ -917,6 +918,13 @@ async function stopFleetAt(dir: string): Promise<number> {
     process.kill(stop.pid, "SIGKILL");
     await waitForReady(() => !pidAlive(stop.pid), 3_000, 100);
   }
+  // Issue 178: pid death is not enough — SIGKILL / mid-exit leaves
+  // lock.json with a fresh heartbeat. Wait until the lock is gone or
+  // the holder pid is dead so the replacement boot can acquire it.
+  const lockClear = await waitForReady(() => isFleetLockFree(dir), 8_000, 100);
+  process.stderr.write(
+    `[stop] pid=${stop.pid} dead=${!pidAlive(stop.pid)} lockFree=${lockClear}\n`
+  );
   // The daemon is gone: clear its pidfile either way.
   rmSync(daemonPidPath(dir), { force: true });
   return stop.pid;

--- a/packages/pi-tidy-bots/src/lock.ts
+++ b/packages/pi-tidy-bots/src/lock.ts
@@ -56,6 +56,32 @@ function isFresh(holder: FleetLockHolder, staleMs: number): boolean {
   return Number.isFinite(age) && age < staleMs;
 }
 
+/** Signal-0 probe — a lock held by a dead pid is an orphan, not an owner. */
+function holderProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Issue 178: true when no *live* owner holds the fleet lock — missing file,
+ * stale heartbeat, or a holder pid that is already gone. Restart must not
+ * treat a dying/dead generation's leftover lock.json as a live owner.
+ */
+export function isFleetLockFree(
+  fleetDir: string,
+  staleMs: number = DEFAULT_STALE_MS
+): boolean {
+  const existing = readHolder(fleetDir);
+  if (!existing) return true;
+  if (!holderProcessAlive(existing.pid)) return true;
+  return !isFresh(existing, staleMs);
+}
+
 /** Atomically replace the lock file, then verify we still own it (race loser detects theft). */
 function writeHolder(fleetDir: string, holder: FleetLockHolder): boolean {
   const path = lockPath(fleetDir);
@@ -67,8 +93,10 @@ function writeHolder(fleetDir: string, holder: FleetLockHolder): boolean {
 }
 
 /**
- * Acquire the fleet session-ownership lock. Refuses while a fresh holder exists;
- * takes over a stale one (dead owner). Heartbeats every `heartbeatMs`.
+ * Acquire the fleet session-ownership lock. Refuses while a fresh *and live*
+ * holder exists; takes over a stale heartbeat or a dead-pid orphan
+ * (issue 178 — SIGKILL / mid-exit skips lock.release() but leaves a
+ * fresh heartbeat). Heartbeats every `heartbeatMs`.
  */
 export function acquireFleetLock(
   fleetDir: string,
@@ -79,7 +107,7 @@ export function acquireFleetLock(
   mkdirSync(join(fleetDir, ".fleet"), { recursive: true });
 
   const existing = readHolder(fleetDir);
-  if (existing && isFresh(existing, staleMs)) {
+  if (existing && !isFleetLockFree(fleetDir, staleMs)) {
     return { ok: false, holder: existing };
   }
 

--- a/packages/pi-tidy-bots/test/boot.test.ts
+++ b/packages/pi-tidy-bots/test/boot.test.ts
@@ -82,6 +82,32 @@ test("probeDaemonIdentity fingerprints the serving fleet (issue 154)", async () 
   );
 });
 
+test("probeDaemonIdentity carries the stored token (issue 178)", async () => {
+  const { probeDaemonIdentity } = await import("../src/cli-core.ts");
+  let seenAuth: string | null = null;
+  const authed = (_url: string, init?: RequestInit) => {
+    seenAuth = new Headers(init?.headers).get("authorization");
+    return Promise.resolve(
+      new Response(JSON.stringify({ fleetDir: "/fleets/alpha" }), {
+        status: 200,
+      })
+    );
+  };
+  assert.deepEqual(
+    await probeDaemonIdentity(4000, "/fleets/alpha", authed, "sekrit"),
+    { kind: "match", fleetDir: "/fleets/alpha" }
+  );
+  assert.equal(seenAuth, "Bearer sekrit", "token rides the identity probe");
+
+  const unauthorized = () =>
+    Promise.resolve(new Response("nope", { status: 401 }));
+  assert.deepEqual(
+    await probeDaemonIdentity(4000, "/fleets/alpha", unauthorized),
+    { kind: "unreachable" },
+    "401 without credentials is not a foreign-fleet match"
+  );
+});
+
 test("daemonCommandMatches recognizes bin and source daemons only (issue 135)", async () => {
   const { daemonCommandMatches, verifyDaemonPid } =
     await import("../src/cli-core.ts");

--- a/packages/pi-tidy-bots/test/lock.test.ts
+++ b/packages/pi-tidy-bots/test/lock.test.ts
@@ -9,7 +9,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { acquireFleetLock } from "../src/lock.ts";
+import { acquireFleetLock, isFleetLockFree } from "../src/lock.ts";
 
 function freshFleetDir(): string {
   const dir = mkdtempSync(join(tmpdir(), "pi-tidy-bots-lock-"));
@@ -68,4 +68,44 @@ test("stale lock is taken over by a new owner", async () => {
   const after = JSON.parse(readFileSync(path, "utf8"));
   assert.notEqual(after.birth, "dead-owner");
   if (acquired.ok) acquired.lock.release();
+});
+
+test("dead holder with a fresh heartbeat is an orphan (issue 178)", () => {
+  const dir = freshFleetDir();
+  const path = join(dir, ".fleet", "lock.json");
+  mkdirSync(join(dir, ".fleet"), { recursive: true });
+  writeFileSync(
+    path,
+    JSON.stringify({
+      pid: 999_999,
+      birth: "killed-mid-exit",
+      host: "local",
+      acquiredAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+    })
+  );
+  assert.equal(
+    isFleetLockFree(dir, 10_000),
+    true,
+    "dead pid is free even when heartbeat is fresh"
+  );
+  const acquired = acquireFleetLock(dir, { heartbeatMs: 50, staleMs: 10_000 });
+  assert.ok(
+    acquired.ok,
+    "replacement boot must take over a dead holder's leftover lock"
+  );
+  const after = JSON.parse(readFileSync(path, "utf8"));
+  assert.notEqual(after.birth, "killed-mid-exit");
+  if (acquired.ok) acquired.lock.release();
+});
+
+test("live holder with a fresh heartbeat still refuses (issue 178)", () => {
+  const dir = freshFleetDir();
+  const first = acquireFleetLock(dir, { heartbeatMs: 50, staleMs: 10_000 });
+  assert.ok(first.ok);
+  assert.equal(isFleetLockFree(dir, 10_000), false, "live owner is not free");
+  const second = acquireFleetLock(dir, { heartbeatMs: 50, staleMs: 10_000 });
+  assert.ok(!second.ok, "must not steal from a live owner");
+  if (first.ok) first.lock.release();
+  assert.equal(isFleetLockFree(dir, 10_000), true, "release frees the lock");
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes Tidy Issues P0 #178 limbo: token-aware identity probe was already on `main` (`d6be0d4`), but Status stayed `ready-for-agent` after verifier’s 2026-09-04 reject (lock race after SIGTERM).

Notion: https://app.notion.com/p/3cf0d7cd1da381b6a4c1cded2ecbea77

## What was already on tip (`d6be0d4`)

- `probeDaemonIdentity(..., token?)` sends `Authorization: Bearer` — token-protected fleets no longer 401 → `unreachable` → swallowed “nothing running” (same-pid false positive).
- `resolveManageableDaemon` reads `readStoredToken(dir)` and passes it to the probe.
- `stopFleetAt` waits for `!pidAlive` (30s grace) and logs `[stop] status=… pid=…` / `SIGTERM delivered`.
- `cmdRestart` does not swallow foreign-pid / foreign-fleet refusals.

## What was still missing (verifier REJECT 2026-09-04 @ 9965955)

Acceptance 1+2 failed: `restart` SIGTERM’d gen-1 then booted gen-2 while `lock.json` still named pid A with a **fresh heartbeat**. Gen-2 died (`fleet lock held by pid A (heartbeat fresh)`), port went dark.

Required: treat a dead/dying holder as an orphan (not a live owner).

## This PR

- `isFleetLockFree` / `acquireFleetLock`: a lock whose holder pid is dead is takeable even when the heartbeat is fresh.
- `stopFleetAt`: after pid death, wait until the lock is free (gone, stale, or dead holder) and log `dead=` / `lockFree=`.
- Regression: dead holder + fresh heartbeat is taken over; live holder still refuses.
- Unit: `probeDaemonIdentity` sends `Bearer` and maps 401 → `unreachable`.

## Offline evidence (no prod `:4317`, no live fleet, no Hermes)

Node **22.22.2** (engines `>=22.19`; system 22.14 cannot type-strip the daemon child — child prints usage and dies).

```
PATH="$(nvm which 22.22.2 | xargs dirname):$PATH"
node -v   # v22.22.2

# 1. Lifecycle suite (includes restart-twice / issue 51)
node --import tsx --test test/lifecycle.test.ts
# PASS  5/5  (9469ms)
#   start --daemon, status, and stop lifecycle
#   restart: sanctioned path preserves token, writes daemon.log, twice (issue 51)
#   cleanup: sanctioned stop before rmSync + port release (issue 162)
#   fresh registry + --port 0
#   daemonize readiness timeout kills the child

# 2. Targeted 178 regressions
node --import tsx --test test/lock.test.ts test/boot.test.ts
# PASS  lock: dead holder with a fresh heartbeat is an orphan (issue 178)
# PASS  lock: live holder with a fresh heartbeat still refuses (issue 178)
# PASS  probeDaemonIdentity carries the stored token (issue 178)
# PASS  probeDaemonIdentity fingerprints the serving fleet (issue 154)

# 3. Typecheck
npm run check --workspace @mobrienv/pi-tidy-bots   # EXIT 0
```

Full `npm test` at repo root is **not** green on this VM for reasons already red on unmodified `main`:

- `orphans.test.ts` — `orphan spawned` (`ps ax` does not show `process.title = stub-pi-orphan`) — reproduced on `d6be0d4` with this change stashed.
- `compaction.test.ts` — `model switch… waitFor` 45s timeout (183-family load flake).

Those are out of scope for #178.

## Foreman

Set Notion **Status → done** after merge. Card body already has the 2026-09-02 PASS notes; the 2026-09-04 comment is the reject this PR answers. No live-fleet bar in this pass (dispatch: offline only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-519eae34-45e7-452b-b51e-3d70500897a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-519eae34-45e7-452b-b51e-3d70500897a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

