### PR TITLE
fix(pi-tidy-bots): stop Already compacted compaction refusal loop

### DIFF
--- a/packages/pi-tidy-bots/src/daemon.ts
+++ b/packages/pi-tidy-bots/src/daemon.ts
@@ -42,7 +42,11 @@ import {
 import { createEventLog, resolveSinceCursor } from "./eventlog.ts";
 import { createRpcEventHandler, deltaThrottleDue } from "./events.ts";
 import { attributionPrefix, stripActionMarkers } from "./actions.ts";
-import { classifyFailure, isRetryable } from "./reasons.ts";
+import {
+  classifyCompactRefusal,
+  classifyFailure,
+  isRetryable,
+} from "./reasons.ts";
 import {
   createTranscriptStore,
   mergeTranscriptHistory,
@@ -445,6 +449,29 @@ export function computeFill(
 ): number | undefined {
   if (contextWindow <= 0) return undefined;
   return inputTokens / contextWindow;
+}
+
+/**
+ * Issue 79 layer 2: pi get_state usage is ground truth over file/window
+ * estimates. Accept the field names real children have used.
+ */
+export function tokensFromGetState(state: unknown): number | undefined {
+  const data =
+    state && typeof state === "object" && "data" in state
+      ? (state as { data?: unknown }).data
+      : state;
+  const usage =
+    data && typeof data === "object" && "usage" in data
+      ? (data as { usage?: unknown }).usage
+      : undefined;
+  if (!usage || typeof usage !== "object") return undefined;
+  const record = usage as Record<string, unknown>;
+  for (const key of ["input", "inputTokens", "promptTokens"] as const) {
+    const value = record[key];
+    if (typeof value === "number" && Number.isFinite(value) && value >= 0)
+      return value;
+  }
+  return undefined;
 }
 
 /** Issue 43 amendment default: flash/spark-class fallback summarizer. */
@@ -1023,31 +1050,17 @@ export function startFleet(options: StartFleetOptions): Promise<FleetHandle> {
    * ran because the daemon's stale estimate said compact while pi's
    * compaction state said done.
    */
+  const applyGetStateTokens = (runtime: BotRuntime, state: unknown): void => {
+    const input = tokensFromGetState(state);
+    if (input === undefined) return;
+    runtime.inputTokens = input;
+    if (runtime.contextWindow)
+      runtime.fill = computeFill(input, runtime.contextWindow);
+  };
+
   const reconcileUsageFromChild = async (runtime: BotRuntime) => {
     try {
-      const state = (await runtime.session?.getState()) as {
-        data?: {
-          usage?: {
-            input?: unknown;
-            inputTokens?: unknown;
-            promptTokens?: unknown;
-          };
-        };
-      };
-      const usage = state?.data?.usage;
-      const input =
-        typeof usage?.input === "number"
-          ? usage.input
-          : typeof usage?.inputTokens === "number"
-            ? usage.inputTokens
-            : typeof usage?.promptTokens === "number"
-              ? usage.promptTokens
-              : undefined;
-      if (input !== undefined && input >= 0) {
-        runtime.inputTokens = input;
-        if (runtime.contextWindow)
-          runtime.fill = computeFill(input, runtime.contextWindow);
-      }
+      applyGetStateTokens(runtime, await runtime.session?.getState());
     } catch {
       /* child unreachable: keep daemon estimates */
     }
@@ -1062,6 +1075,10 @@ export function startFleet(options: StartFleetOptions): Promise<FleetHandle> {
     // pi-core 0.85.0 crash class (undefined.signal in the child's manual-
     // compact path): deterministic per child — respawn clears the blackout.
     if (runtime.compactCrashBlackout) return false;
+    // Issue 79 layer 2: prefer the child's get_state tokens before deciding
+    // whether compact is even warranted — stale file/window estimates are
+    // what kept forcing a terminal no-op overnight.
+    await reconcileUsageFromChild(runtime);
     const trigger: "threshold" | "idle" | "force" = opts.force
       ? "force"
       : opts.idle === true
@@ -1164,7 +1181,8 @@ export function startFleet(options: StartFleetOptions): Promise<FleetHandle> {
       // failure; the old classifier fed it to escalation as
       // delivery_failed and retried at every settled boundary (118+
       // identical entries overnight).
-      if (/already compacted/i.test(String(error))) {
+      const compactRefusal = classifyCompactRefusal(String(error));
+      if (compactRefusal === "already_compacted") {
         // Restore the session model first if a fallback switch happened.
         if (fallback && sessionModelId) {
           try {
@@ -1221,8 +1239,7 @@ export function startFleet(options: StartFleetOptions): Promise<FleetHandle> {
         );
         return true;
       }
-      refused = /nothing to compact/i.test(String(error));
-      refused = /nothing to compact/i.test(String(error));
+      refused = compactRefusal === "nothing_to_compact";
       if (!refused) {
         const errorText = String(error);
         // pi-core 0.85.0 crash class: the child's manual-compact path can
@@ -1561,6 +1578,9 @@ export function startFleet(options: StartFleetOptions): Promise<FleetHandle> {
         (state as any)?.data?.contextWindow;
       if (typeof window === "number" && window > 0)
         runtime.contextWindow = window;
+      // Issue 79: prefer the child's get_state token count when it reports
+      // one — file/window estimates are the fallback, not the source.
+      applyGetStateTokens(runtime, state);
       // Issue 43 amendment: every window (re)learn recomputes fill from the
       // tokens we already carry and schedules a FORCED compaction at the
       // next settled boundary when fill ≥ 60% of the NEW window — a model

--- a/packages/pi-tidy-bots/src/reasons.ts
+++ b/packages/pi-tidy-bots/src/reasons.ts
@@ -53,6 +53,23 @@ export function classifyFailure(message: string): Reason {
   return "delivery_failed";
 }
 
+/**
+ * Issue 79: pi compact refusals are terminal no-ops, not delivery failures.
+ * classifyFailure("Already compacted") still falls through to delivery_failed
+ * — that misclass is what retried at every settled boundary (118+ spam).
+ * Compact paths MUST consult this first.
+ */
+export type CompactRefusal = "already_compacted" | "nothing_to_compact";
+
+export function classifyCompactRefusal(
+  message: string
+): CompactRefusal | undefined {
+  const lowered = message.toLowerCase();
+  if (lowered.includes("already compacted")) return "already_compacted";
+  if (lowered.includes("nothing to compact")) return "nothing_to_compact";
+  return undefined;
+}
+
 export function isRetryable(reason: string): boolean {
   return (RETRYABLE as string[]).includes(reason);
 }

--- a/packages/pi-tidy-bots/src/rpc.ts
+++ b/packages/pi-tidy-bots/src/rpc.ts
@@ -319,8 +319,14 @@ export const PROMPT_CLASS_TIMEOUT_MS = 10 * 60_000;
 
 /** Correlated native refusal, distinct from transport loss or a timeout. */
 export class RpcCommandRejected extends Error {
-  constructor() {
-    super("Native RPC command was rejected");
+  readonly remoteError?: string;
+  constructor(remoteError?: string) {
+    super(
+      remoteError
+        ? `Native RPC command was rejected: ${remoteError}`
+        : "Native RPC command was rejected"
+    );
+    this.remoteError = remoteError;
   }
 }
 
@@ -656,9 +662,11 @@ export class RpcSession {
         if (pending) {
           this.pending.delete(id);
           if (parsed.success === false) {
+            const remoteError =
+              typeof parsed.error === "string" ? parsed.error : undefined;
             pending.reject(
               this.options.nativeProtocol
-                ? new RpcCommandRejected()
+                ? new RpcCommandRejected(remoteError)
                 : new Error(`rpc command failed: ${line}`)
             );
           } else {

--- a/packages/pi-tidy-bots/test/compaction-refusal.test.ts
+++ b/packages/pi-tidy-bots/test/compaction-refusal.test.ts
@@ -12,6 +12,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tokensFromGetState } from "../src/daemon.ts";
 
 // Issue 79 (P0): "Already compacted" is a TERMINAL NO-OP refusal, not a
 // delivery failure. Layers:
@@ -38,6 +39,13 @@ async function waitFor(
 interface Harness {
   base: string;
   stop(): Promise<void>;
+}
+
+function compactAsks(tracePath: string): number {
+  if (!existsSync(tracePath)) return 0;
+  return readFileSync(tracePath, "utf8")
+    .split("\n")
+    .filter((line) => line.includes('"kind":"compact"')).length;
 }
 
 async function boot(
@@ -69,246 +77,319 @@ async function boot(
   };
 }
 
-test("always-refusing child: terminal no-op, one entry, no spam (79)", async () => {
-  const fleetDir = mkdtempSync(join(tmpdir(), "ptb-79-"));
-  const stops: Array<() => Promise<void>> = [];
-  try {
-    mkdirSync(join(fleetDir, "bots", "aa"), { recursive: true });
-    writeFileSync(join(fleetDir, "bots", "aa", "AGENTS.md"), "# aa\n");
-    writeFileSync(
-      join(fleetDir, "bots.toml"),
-      `[[bot]]\nname = "aa"\ndir = "bots/aa"\n`
-    );
+test("tokensFromGetState prefers pi usage fields", () => {
+  assert.equal(
+    tokensFromGetState({ data: { usage: { input: 90000 } } }),
+    90000
+  );
+  assert.equal(
+    tokensFromGetState({ data: { usage: { inputTokens: 12 } } }),
+    12
+  );
+  assert.equal(tokensFromGetState({ data: { usage: { promptTokens: 7 } } }), 7);
+  assert.equal(tokensFromGetState({ data: { model: {} } }), undefined);
+  assert.equal(tokensFromGetState({ usage: { input: 3 } }), 3);
+});
 
-    // High fill per turn usage (90k/128k = 70%) forces compaction at the
-    // settled boundary; the child ALWAYS refuses "Already compacted" and
-    // its own get_state usage agrees the context is big — the exact
-    // overnight machine.
-    process.env.PTB_STUB_USAGE = "90000";
-    process.env.PTB_STUB_COMPACT_REFUSAL = "already";
-    process.env.PTB_STUB_STATE_USAGE = "90000";
-    const h = await boot(fleetDir, {});
-    stops.push(() => h.stop());
-
-    await waitFor(async () =>
-      (
-        (await (await fetch(`${h.base}/api/fleet`)).json()) as {
-          bots: { online: boolean }[];
-        }
-      ).bots.every((b) => b.online)
-    );
-
-    const sendTurn = () =>
-      fetch(`${h.base}/api/bots/aa/message`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ text: "another turn" }),
-      });
-
-    // Drive MANY settled boundaries — at HEAD this spammed one failure
-    // entry per boundary (118+ overnight).
-    for (let i = 0; i < 6; i++) {
-      await sendTurn();
-      await new Promise((r) => setTimeout(r, 1200));
-    }
-
-    const transcript = () =>
-      fetch(`${h.base}/api/bots/aa/transcript`).then(
-        (res) =>
-          res.json() as Promise<{
-            transcript: { role: string; text: string }[];
-          }>
+test(
+  "always-refusing child: terminal no-op, one entry, no spam (79)",
+  { timeout: 60000 },
+  async () => {
+    const fleetDir = mkdtempSync(join(tmpdir(), "ptb-79-"));
+    const stops: Array<() => Promise<void>> = [];
+    const tracePath = join(fleetDir, "stub-trace.jsonl");
+    try {
+      mkdirSync(join(fleetDir, "bots", "aa"), { recursive: true });
+      writeFileSync(join(fleetDir, "bots", "aa", "AGENTS.md"), "# aa\n");
+      writeFileSync(
+        join(fleetDir, "bots.toml"),
+        `[[bot]]\nname = "aa"\ndir = "bots/aa"\n`
       );
-    const entries = (await transcript()).transcript;
-    const refusalEntries = entries.filter((e) =>
-      /already compacted/i.test(e.text)
-    );
-    const failureEntries = entries.filter((e) =>
-      /Context management FAILED/i.test(e.text)
-    );
-    assert.equal(
-      refusalEntries.length,
-      1,
-      `exactly ONE terminal-no-op entry (got ${refusalEntries.length}: ${refusalEntries.map((e) => e.text)})`
-    );
-    assert.equal(
-      failureEntries.length,
-      0,
-      "never classified as a delivery failure"
-    );
 
-    // The compact RPC was asked at most twice (initial + the allowed one
-    // retry), not once per turn.
-    const tracePath = process.env.PTB_STUB_TRACE;
-    if (tracePath && existsSync(tracePath)) {
-      const trace = readFileSync(tracePath, "utf8");
-      const asks = (trace.match(/compact/g) ?? []).length;
+      // High fill per turn usage (90k/128k = 70%) forces compaction at the
+      // settled boundary; the child ALWAYS refuses "Already compacted" and
+      // its own get_state usage agrees the context is big — the exact
+      // overnight machine.
+      process.env.PTB_STUB_USAGE = "90000";
+      process.env.PTB_STUB_COMPACT_REFUSAL = "already";
+      process.env.PTB_STUB_STATE_USAGE = "90000";
+      process.env.PTB_STUB_TRACE = tracePath;
+      const h = await boot(fleetDir, {});
+      stops.push(() => h.stop());
+
+      await waitFor(async () =>
+        (
+          (await (await fetch(`${h.base}/api/fleet`)).json()) as {
+            bots: { online: boolean }[];
+          }
+        ).bots.every((b) => b.online)
+      );
+
+      const sendTurn = () =>
+        fetch(`${h.base}/api/bots/aa/message`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ text: "another turn" }),
+        });
+      const transcript = () =>
+        fetch(`${h.base}/api/bots/aa/transcript`).then(
+          (res) =>
+            res.json() as Promise<{
+              transcript: { role: string; text: string }[];
+            }>
+        );
+
+      // Drive MANY settled boundaries — at HEAD this spammed one failure
+      // entry per boundary (118+ overnight).
+      for (let i = 0; i < 6; i++) {
+        await sendTurn();
+        await waitFor(async () => {
+          const done = (await transcript()).transcript.filter(
+            (e) => e.text === "done"
+          ).length;
+          return done >= i + 1;
+        });
+      }
+
+      const entries = (await transcript()).transcript;
+      const refusalEntries = entries.filter((e) =>
+        /already compacted/i.test(e.text)
+      );
+      const failureEntries = entries.filter((e) =>
+        /Context management FAILED/i.test(e.text)
+      );
+      assert.equal(
+        refusalEntries.length,
+        1,
+        `exactly ONE terminal-no-op entry (got ${refusalEntries.length}: ${refusalEntries.map((e) => e.text)})`
+      );
+      assert.equal(
+        failureEntries.length,
+        0,
+        "never classified as a delivery failure"
+      );
+
+      // The compact RPC was asked at most twice (initial + the allowed one
+      // retry), not once per turn.
+      const asks = compactAsks(tracePath);
       assert.ok(
-        asks <= 2,
+        asks >= 1 && asks <= 2,
         `compact asked at most twice across 6 turns (got ${asks})`
       );
+
+      // Bookkeeping: fill stays truthful (child's numbers), suppression armed.
+      const context = (await (
+        await fetch(`${h.base}/api/bots/aa/context`)
+      ).json()) as { fill?: number };
+      assert.ok(
+        context.fill === undefined || context.fill >= 0,
+        "fill readable"
+      );
+    } finally {
+      delete process.env.PTB_STUB_USAGE;
+      delete process.env.PTB_STUB_COMPACT_REFUSAL;
+      delete process.env.PTB_STUB_STATE_USAGE;
+      delete process.env.PTB_STUB_TRACE;
+      await Promise.all(stops.map((s) => s().catch(() => {})));
+      rmSync(fleetDir, { recursive: true, force: true });
     }
-
-    // Bookkeeping: fill stays truthful (child's numbers), suppression armed.
-    const context = (await (
-      await fetch(`${h.base}/api/bots/aa/context`)
-    ).json()) as { fill?: number };
-    assert.ok(context.fill === undefined || context.fill >= 0, "fill readable");
-  } finally {
-    delete process.env.PTB_STUB_USAGE;
-    delete process.env.PTB_STUB_COMPACT_REFUSAL;
-    delete process.env.PTB_STUB_STATE_USAGE;
-    await Promise.all(stops.map((s) => s().catch(() => {})));
-    rmSync(fleetDir, { recursive: true, force: true });
   }
-});
+);
 
-test("reconciliation drops fill: pi numbers beat daemon math (79 layer 2)", async () => {
-  const fleetDir = mkdtempSync(join(tmpdir(), "ptb-79r-"));
-  const stops: Array<() => Promise<void>> = [];
-  try {
-    mkdirSync(join(fleetDir, "bots", "aa"), { recursive: true });
-    writeFileSync(join(fleetDir, "bots", "aa", "AGENTS.md"), "# aa\n");
-    writeFileSync(
-      join(fleetDir, "bots.toml"),
-      `[[bot]]\nname = "aa"\ndir = "bots/aa"\n`
-    );
+test(
+  "reconciliation drops fill: pi numbers beat daemon math (79 layer 2)",
+  { timeout: 60000 },
+  async () => {
+    const fleetDir = mkdtempSync(join(tmpdir(), "ptb-79r-"));
+    const stops: Array<() => Promise<void>> = [];
+    const tracePath = join(fleetDir, "stub-trace.jsonl");
+    try {
+      mkdirSync(join(fleetDir, "bots", "aa"), { recursive: true });
+      writeFileSync(join(fleetDir, "bots", "aa", "AGENTS.md"), "# aa\n");
+      writeFileSync(
+        join(fleetDir, "bots.toml"),
+        `[[bot]]\nname = "aa"\ndir = "bots/aa"\n`
+      );
 
-    // Daemon estimate high (turn usage 90k), but the child's OWN state
-    // says 10k — compaction already happened inside pi. The daemon must
-    // adopt the child's number and STOP, not keep forcing.
-    process.env.PTB_STUB_USAGE = "90000";
-    process.env.PTB_STUB_COMPACT_REFUSAL = "already";
-    process.env.PTB_STUB_STATE_USAGE = "10000";
-    const h = await boot(fleetDir, {});
-    stops.push(() => h.stop());
+      // Daemon estimate high (turn usage 90k), but the child's OWN state
+      // says 10k — compaction already happened inside pi. The daemon must
+      // adopt the child's number and STOP, not keep forcing.
+      process.env.PTB_STUB_USAGE = "90000";
+      process.env.PTB_STUB_COMPACT_REFUSAL = "already";
+      process.env.PTB_STUB_STATE_USAGE = "10000";
+      process.env.PTB_STUB_TRACE = tracePath;
+      const h = await boot(fleetDir, {});
+      stops.push(() => h.stop());
 
-    await waitFor(async () =>
-      (
-        (await (await fetch(`${h.base}/api/fleet`)).json()) as {
-          bots: { online: boolean }[];
-        }
-      ).bots.every((b) => b.online)
-    );
-    for (let i = 0; i < 4; i++) {
+      await waitFor(async () =>
+        (
+          (await (await fetch(`${h.base}/api/fleet`)).json()) as {
+            bots: { online: boolean }[];
+          }
+        ).bots.every((b) => b.online)
+      );
+      for (let i = 0; i < 4; i++) {
+        await fetch(`${h.base}/api/bots/aa/message`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ text: "turn" }),
+        });
+        await waitFor(async () => {
+          const entries = (
+            (await (
+              await fetch(`${h.base}/api/bots/aa/transcript`)
+            ).json()) as {
+              transcript: { text: string }[];
+            }
+          ).transcript;
+          return entries.filter((e) => e.text === "done").length >= i + 1;
+        });
+      }
+      const entries = (
+        await (await fetch(`${h.base}/api/bots/aa/transcript`)).json()
+      ).transcript as { role: string; text: string }[];
+      const refusalEntries = entries.filter((e) =>
+        /already compacted/i.test(e.text)
+      );
+      const failureEntries = entries.filter((e) =>
+        /Context management FAILED/i.test(e.text)
+      );
+      assert.equal(
+        refusalEntries.length,
+        0,
+        "get_state tokens win before compact is asked"
+      );
+      assert.equal(failureEntries.length, 0, "no delivery-failure spam");
+      assert.equal(
+        compactAsks(tracePath),
+        0,
+        "child numbers below trigger: never ask compact"
+      );
+      await waitFor(async () => {
+        const context = (await (
+          await fetch(`${h.base}/api/bots/aa/context`)
+        ).json()) as { inputTokens?: number | null };
+        return context.inputTokens === 10000;
+      });
+      const context = (await (
+        await fetch(`${h.base}/api/bots/aa/context`)
+      ).json()) as { fill?: number | null; inputTokens?: number | null };
+      assert.equal(context.inputTokens, 10000);
+      assert.ok(
+        context.fill !== undefined &&
+          context.fill !== null &&
+          context.fill < 0.6,
+        "fill follows the child's get_state tokens, not turn-usage math"
+      );
+    } finally {
+      delete process.env.PTB_STUB_USAGE;
+      delete process.env.PTB_STUB_COMPACT_REFUSAL;
+      delete process.env.PTB_STUB_STATE_USAGE;
+      delete process.env.PTB_STUB_TRACE;
+      await Promise.all(stops.map((s) => s().catch(() => {})));
+      rmSync(fleetDir, { recursive: true, force: true });
+    }
+  }
+);
+
+test(
+  "true overflow after reconciliation: ONE reset, loop terminates (79 layer 3)",
+  { timeout: 60000 },
+  async () => {
+    const fleetDir = mkdtempSync(join(tmpdir(), "ptb-79x-"));
+    const stops: Array<() => Promise<void>> = [];
+    try {
+      mkdirSync(join(fleetDir, "bots", "aa"), { recursive: true });
+      writeFileSync(join(fleetDir, "bots", "aa", "AGENTS.md"), "# aa\n");
+      writeFileSync(
+        join(fleetDir, "bots.toml"),
+        `[[bot]]\nname = "aa"\ndir = "bots/aa"\n`
+      );
+
+      // The child refuses compaction AND its own numbers say the context is
+      // OVER the window — the genuine-overflow case. The issue 43 amendment
+      // reset must fire ONCE; the respawned (fresh) child then reports a
+      // healthy context and the machine stays quiet.
+      const usageFile = join(fleetDir, "state-usage.txt");
+      writeFileSync(usageFile, "140000"); // window is 128000
+      process.env.PTB_STUB_USAGE = "140000";
+      process.env.PTB_STUB_COMPACT_REFUSAL = "already";
+      process.env.PTB_STUB_STATE_USAGE_FILE = usageFile;
+      const h = await boot(fleetDir, {});
+      stops.push(() => h.stop());
+
+      await waitFor(async () =>
+        (
+          (await (await fetch(`${h.base}/api/fleet`)).json()) as {
+            bots: { online: boolean }[];
+          }
+        ).bots.every((b) => b.online)
+      );
+
+      const entries = () =>
+        fetch(`${h.base}/api/bots/aa/transcript`).then(
+          (res) =>
+            res.json() as Promise<{
+              transcript: { role: string; text: string }[];
+            }>
+        );
+
+      // Drive the turn that trips the machine (settled boundary).
       await fetch(`${h.base}/api/bots/aa/message`, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ text: "turn" }),
+        body: JSON.stringify({ text: "go" }),
       });
-      await new Promise((r) => setTimeout(r, 1000));
-    }
-    const entries = (
-      await (await fetch(`${h.base}/api/bots/aa/transcript`)).json()
-    ).transcript as { role: string; text: string }[];
-    const refusalEntries = entries.filter((e) =>
-      /already compacted/i.test(e.text)
-    );
-    assert.equal(refusalEntries.length, 1, "one reconciliation entry");
-    assert.match(
-      refusalEntries[0]?.text ?? "",
-      /\d+%/,
-      "entry carries the reconciled fill"
-    );
-  } finally {
-    delete process.env.PTB_STUB_USAGE;
-    delete process.env.PTB_STUB_COMPACT_REFUSAL;
-    delete process.env.PTB_STUB_STATE_USAGE;
-    await Promise.all(stops.map((s) => s().catch(() => {})));
-    rmSync(fleetDir, { recursive: true, force: true });
-  }
-});
 
-test("true overflow after reconciliation: ONE reset, loop terminates (79 layer 3)", async () => {
-  const fleetDir = mkdtempSync(join(tmpdir(), "ptb-79x-"));
-  const stops: Array<() => Promise<void>> = [];
-  try {
-    mkdirSync(join(fleetDir, "bots", "aa"), { recursive: true });
-    writeFileSync(join(fleetDir, "bots", "aa", "AGENTS.md"), "# aa\n");
-    writeFileSync(
-      join(fleetDir, "bots.toml"),
-      `[[bot]]\nname = "aa"\ndir = "bots/aa"\n`
-    );
-
-    // The child refuses compaction AND its own numbers say the context is
-    // OVER the window — the genuine-overflow case. The issue 43 amendment
-    // reset must fire ONCE; the respawned (fresh) child then reports a
-    // healthy context and the machine stays quiet.
-    const usageFile = join(fleetDir, "state-usage.txt");
-    writeFileSync(usageFile, "140000"); // window is 128000
-    process.env.PTB_STUB_USAGE = "140000";
-    process.env.PTB_STUB_COMPACT_REFUSAL = "already";
-    process.env.PTB_STUB_STATE_USAGE_FILE = usageFile;
-    const h = await boot(fleetDir, {});
-    stops.push(() => h.stop());
-
-    await waitFor(async () =>
-      (
-        (await (await fetch(`${h.base}/api/fleet`)).json()) as {
-          bots: { online: boolean }[];
-        }
-      ).bots.every((b) => b.online)
-    );
-
-    const entries = () =>
-      fetch(`${h.base}/api/bots/aa/transcript`).then(
-        (res) =>
-          res.json() as Promise<{
-            transcript: { role: string; text: string }[];
-          }>
+      // The reset entry appears once.
+      await waitFor(async () =>
+        (await entries()).transcript.some((e) =>
+          /escalating to session reset/i.test(e.text)
+        )
       );
+      // The fresh session reports healthy usage from here on.
+      writeFileSync(usageFile, "10000");
 
-    // Drive the turn that trips the machine (settled boundary).
-    await fetch(`${h.base}/api/bots/aa/message`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ text: "go" }),
-    });
-
-    // The reset entry appears once.
-    await waitFor(async () =>
-      (await entries()).transcript.some((e) =>
+      // Drive more settled boundaries — no second reset, no spam.
+      for (let i = 0; i < 4; i++) {
+        await fetch(`${h.base}/api/bots/aa/message`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ text: "turn" }),
+        });
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+      const finalEntries = (await entries()).transcript;
+      const resets = finalEntries.filter((e) =>
         /escalating to session reset/i.test(e.text)
-      )
-    );
-    // The fresh session reports healthy usage from here on.
-    writeFileSync(usageFile, "10000");
-
-    // Drive more settled boundaries — no second reset, no spam.
-    for (let i = 0; i < 4; i++) {
-      await fetch(`${h.base}/api/bots/aa/message`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ text: "turn" }),
-      });
-      await new Promise((r) => setTimeout(r, 1000));
-    }
-    const finalEntries = (await entries()).transcript;
-    const resets = finalEntries.filter((e) =>
-      /escalating to session reset/i.test(e.text)
-    );
-    const failures = finalEntries.filter((e) =>
-      /Context management FAILED/i.test(e.text)
-    );
-    assert.equal(resets.length, 1, "exactly ONE reset — worst case terminates");
-    assert.equal(
-      failures.length,
-      resets.length,
-      "no delivery-failure spam beyond the reset entry itself"
-    );
-    // Evidence kept: the oversized session moved aside, never deleted.
-    const sessionsDir = join(fleetDir, ".fleet", "sessions");
-    if (existsSync(sessionsDir)) {
-      const kept = readdirSync(sessionsDir).filter((n) =>
-        n.startsWith("aa.pre-reset-")
       );
-      assert.ok(kept.length >= 1, "oversized session evidence preserved");
+      const failures = finalEntries.filter((e) =>
+        /Context management FAILED/i.test(e.text)
+      );
+      assert.equal(
+        resets.length,
+        1,
+        "exactly ONE reset — worst case terminates"
+      );
+      assert.equal(
+        failures.length,
+        resets.length,
+        "no delivery-failure spam beyond the reset entry itself"
+      );
+      // Evidence kept: the oversized session moved aside, never deleted.
+      const sessionsDir = join(fleetDir, ".fleet", "sessions");
+      if (existsSync(sessionsDir)) {
+        const kept = readdirSync(sessionsDir).filter((n) =>
+          n.startsWith("aa.pre-reset-")
+        );
+        assert.ok(kept.length >= 1, "oversized session evidence preserved");
+      }
+    } finally {
+      delete process.env.PTB_STUB_USAGE;
+      delete process.env.PTB_STUB_COMPACT_REFUSAL;
+      delete process.env.PTB_STUB_STATE_USAGE_FILE;
+      await Promise.all(stops.map((s) => s().catch(() => {})));
+      rmSync(fleetDir, { recursive: true, force: true });
     }
-  } finally {
-    delete process.env.PTB_STUB_USAGE;
-    delete process.env.PTB_STUB_COMPACT_REFUSAL;
-    delete process.env.PTB_STUB_STATE_USAGE_FILE;
-    await Promise.all(stops.map((s) => s().catch(() => {})));
-    rmSync(fleetDir, { recursive: true, force: true });
   }
-});
+);

--- a/packages/pi-tidy-bots/test/gateway-entry-parity.test.ts
+++ b/packages/pi-tidy-bots/test/gateway-entry-parity.test.ts
@@ -736,16 +736,16 @@ test(
       );
       assert.deepEqual(
         await fleet.request("/api/bots/aa/compact", {}),
-        expected.compactionRefusal
+        expected.compactionAlreadyDone
       );
       assert.equal(
         fleet
           .native()
-          .some(
+          .filter(
             (item) => item.direction === "in" && item.frame.type === "compact"
-          ),
-        false,
-        "unknown fill makes compacted=false before native execution"
+          ).length,
+        1,
+        "get_state tokens make fill known so force compact reaches the child once"
       );
       await fleet.request("/api/bots/aa/message", { text: "usage" });
       await until(
@@ -759,10 +759,17 @@ test(
         await fleet.request("/api/bots/aa/compact", {}),
         expected.compactionAlreadyDone
       );
+      const already = (await fleet.transcript()).filter((item) =>
+        /already compacted/i.test(item.text)
+      );
+      assert.ok(already.length >= 1, "terminal no-op is visible once");
       assert.ok(
-        (await fleet.transcript()).some((item) =>
-          /already compacted/i.test(item.text)
-        )
+        fleet
+          .native()
+          .filter(
+            (item) => item.direction === "in" && item.frame.type === "compact"
+          ).length <= 2,
+        "at most one retry after the first already-compacted refusal"
       );
     } finally {
       await fleet.dispose();

--- a/packages/pi-tidy-bots/test/reasons.test.ts
+++ b/packages/pi-tidy-bots/test/reasons.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { classifyFailure, isRetryable } from "../src/reasons.ts";
+import {
+  classifyCompactRefusal,
+  classifyFailure,
+  isRetryable,
+} from "../src/reasons.ts";
 
 test("classifies provider and delivery failures into typed reasons", () => {
   assert.equal(
@@ -40,10 +44,29 @@ test("issue 49 follow-up: compact refusal on a small session is not a fatal", ()
   // A forced compact on a small session: pi refuses; the daemon must treat
   // the refusal as a noop success, never a 500.
   assert.equal(
+    classifyCompactRefusal("Nothing to compact (session too small)"),
+    "nothing_to_compact"
+  );
+  assert.equal(
     classifyFailure("Nothing to compact (session too small)"),
     "delivery_failed",
-    "the refusal is a clean noop, not offline/port/usage"
+    "the delivery classifier is the wrong layer — compact paths must not use it"
   );
+});
+
+test("issue 79: Already compacted is a terminal compact no-op", () => {
+  for (const message of [
+    "Already compacted",
+    'rpc command failed: {"success":false,"error":"Already compacted"}',
+    "Native RPC command was rejected: Already compacted",
+  ]) {
+    assert.equal(classifyCompactRefusal(message), "already_compacted", message);
+  }
+  assert.equal(classifyCompactRefusal("mystery"), undefined);
+  // The delivery classifier still falls through — that is the overnight
+  // loop if compact paths forget to consult classifyCompactRefusal first.
+  assert.equal(classifyFailure("Already compacted"), "delivery_failed");
+  assert.ok(!isRetryable("delivery_failed"));
 });
 
 test("issue 50: a busy child is turn_in_flight, never runtime_offline", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes Tidy Issues #79 (P0): pi compact RPC `Already compacted` was classified as `delivery_failed` and retried at every settled boundary (118+ identical transcript entries).

**Notion:** [Compaction refusal 'Already compacted' loops forever as delivery_failed](https://app.notion.com/p/3d00d7cd1da3817694aac3b847eb9f5a)

Foreman: please set Notion Status to **ready-for-human** and attach this PR. Do not undraft #68.

## Acceptance

1. **Always-refusing stub cannot spam.** `compaction-refusal.test.ts` drives 6 settled boundaries against a child that always returns `Already compacted`. Exactly one system transcript entry; zero `Context management FAILED` entries; compact RPC asked at most twice.
2. **Terminal no-op class.** New `classifyCompactRefusal()` runs *before* `classifyFailure()`. `Already compacted` is `already_compacted` (not `delivery_failed`). Loop ends after at most one retry. Native `RpcCommandRejected` now carries the remote error text so the gateway path can classify it too.
3. **Prefer `get_state` tokens.** `tokensFromGetState()` reads `usage.input` / `inputTokens` / `promptTokens`. Spawn + `maybeCompact` adopt those numbers before deciding whether to compact. When the child reports a low fill, compact is not asked at all.
4. **Issue 43 overflow still terminates in one reset.** Genuine over-window after reconciliation still escalates once; further turns do not spam.

## Files

- `packages/pi-tidy-bots/src/reasons.ts` — `classifyCompactRefusal`
- `packages/pi-tidy-bots/src/daemon.ts` — reconcile-first compact decision; `tokensFromGetState`
- `packages/pi-tidy-bots/src/rpc.ts` — `RpcCommandRejected` preserves remote error
- `packages/pi-tidy-bots/test/compaction-refusal.test.ts` — regression + get_state preference
- `packages/pi-tidy-bots/test/reasons.test.ts` — unit classification
- `packages/pi-tidy-bots/test/gateway-entry-parity.test.ts` — force-compact now uses get_state fill

No README/CHANGELOG/ADR. No live Hermes smoke. No prod `:4317` writes. No edits to #68.

## Evidence (commands + pass/fail)

| Command | Result |
|---|---|
| `node --import tsx --test test/reasons.test.ts test/compaction-refusal.test.ts` (in `packages/pi-tidy-bots`) | **PASS** 9/9 |
| `node --import tsx --test --test-name-pattern='real prompt timeout is unknown' test/gateway-entry-parity.test.ts` | **PASS** 1/1 |
| `npm run check` (in `packages/pi-tidy-bots`) | **PASS** |
| `npm test` (in `packages/pi-tidy-bots`) | **FAIL** 375/642 — pre-existing `unsupported_sqlite` / Python / Hermes on Node 22.14.0. Issue 79 cells all passed (`always-refusing child`, `reconciliation drops fill`, `true overflow`, `issue 79: Already compacted`). Same environment block as #68 (`TIDY_TEST_PYTHON` / certified CPython+SQLite). Not a compaction regression. |

Targeted red→green: `classifyFailure("Already compacted")` is still `delivery_failed` (the overnight loop if compact paths forget the new classifier). Compact paths now consult `classifyCompactRefusal` first.

Commit: `feb8e8c`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff37bc15-6403-456b-8769-a68ef84f8da1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff37bc15-6403-456b-8769-a68ef84f8da1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

