### PR TITLE
fix(pi-tidy-bots): expire sticky delivering + fail-closed health probe

### DIFF
--- a/packages/pi-tidy-bots/scripts/health-probe.sh
+++ b/packages/pi-tidy-bots/scripts/health-probe.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Fail-closed Atlas/fleet health probe.
+#
+# Source of truth lives in this package (pi-tidy-bots). Rook's fleet copy
+# at bots/atlas/health-probe.sh is NOT in this repo — point that wrapper
+# here (or `pi-tidy-bots health`) so sticky delivering and over-budget
+# context fail the probe.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+url="${1:-${PTB_HEALTH_URL:-http://127.0.0.1:4317}}"
+shift || true
+
+exec node --import tsx "$root/src/health-probe.ts" --url "$url" "$@"

--- a/packages/pi-tidy-bots/src/cli.ts
+++ b/packages/pi-tidy-bots/src/cli.ts
@@ -74,6 +74,7 @@ const COMMAND_FLAGS: Record<string, string[]> = {
   ],
   add: ["dir", "title", "avatar", "description"],
   chat: ["bot", "url", "token"],
+  health: ["bot", "url", "token", "stale-min", "token-budget"],
   status: ["fleet"],
   stop: ["fleet"],
   restart: ["fleet"],
@@ -128,6 +129,7 @@ Usage:
   pi-tidy-bots add <name> [--dir fleetDir] [--title t] [--avatar e] [--description d]
                                           Scaffold a bot and append its manifest row
   pi-tidy-bots status [fleetDir]          Show daemon pid, port, per-bot state
+  pi-tidy-bots health [url]               Fail-closed probe: stale delivering or over-budget context
   pi-tidy-bots fleets [--prune]           List registered fleets and running state
   pi-tidy-bots start --fleet <name>       Target a registered fleet by name
   pi-tidy-bots stop [fleetDir]            Gracefully stop the running fleet
@@ -1129,6 +1131,29 @@ export async function main(): Promise<void> {
     if (command === "chat") return void (await cmdChat(args));
     if (command === "add") cmdAdd(args);
     if (command === "start") return void (await cmdStart(args));
+    if (command === "health") {
+      const { runHealthProbeCli } = await import("./health-probe.ts");
+      const argv = [
+        ...(typeof args.flags.url === "string"
+          ? ["--url", args.flags.url]
+          : args.positional[0]
+            ? [args.positional[0]]
+            : []),
+        ...(typeof args.flags.bot === "string"
+          ? ["--bot", args.flags.bot]
+          : []),
+        ...(typeof args.flags.token === "string"
+          ? ["--token", args.flags.token]
+          : []),
+        ...(typeof args.flags["stale-min"] === "string"
+          ? ["--stale-min", args.flags["stale-min"]]
+          : []),
+        ...(typeof args.flags["token-budget"] === "string"
+          ? ["--token-budget", args.flags["token-budget"]]
+          : []),
+      ];
+      process.exit(await runHealthProbeCli(argv));
+    }
     if (command === "status") {
       await cmdStatus(args, args.flags.json === true);
       return;

--- a/packages/pi-tidy-bots/src/daemon.ts
+++ b/packages/pi-tidy-bots/src/daemon.ts
@@ -52,6 +52,8 @@ import {
   mergeTranscriptHistory,
   paginateTranscript,
 } from "./transcripts.ts";
+import { reconcileDelivering } from "./delivering.ts";
+import { evaluateFleetHealth } from "./health-probe.ts";
 import { createPendingStore, type PendingMessage } from "./pending.ts";
 import { createOperatorQueueStore } from "./operator-queue.ts";
 import { TurnPartsAccumulator, type TurnPart } from "./turnparts.ts";
@@ -835,6 +837,42 @@ export function startFleet(options: StartFleetOptions): Promise<FleetHandle> {
       runtime.transcript.splice(0, runtime.transcript.length - 500);
     transcripts.append(runtime.config.name, entry);
     emit({ type: "append", bot: runtime.config.name, entry });
+  };
+
+  const persistDeliveringClears = (
+    runtime: BotRuntime,
+    cleared: TranscriptEntry[]
+  ): void => {
+    if (cleared.length === 0) return;
+    // Journal appends write delivering:true once; a save rewrites the
+    // current generation so a restart cannot rehydrate sticky flags.
+    transcripts.save(runtime.config.name, runtime.transcript);
+    for (const entry of cleared) {
+      emit({ type: "append", bot: runtime.config.name, entry });
+    }
+  };
+
+  const sweepDelivering = (
+    runtime: BotRuntime,
+    opts: { settled?: boolean } = {}
+  ): TranscriptEntry[] => {
+    const cleared = reconcileDelivering(runtime.transcript, {
+      pendingIds: pendingStore.load(runtime.config.name).map((m) => m.id),
+      activeDeliveryId: runtime.activeDeliveryId,
+      streaming: runtime.session?.streaming === true,
+      settled: opts.settled,
+    });
+    persistDeliveringClears(runtime, cleared);
+    return cleared;
+  };
+
+  const markNotDelivering = (
+    runtime: BotRuntime,
+    entry: TranscriptEntry | undefined
+  ): void => {
+    if (!entry || entry.delivering !== true) return;
+    entry.delivering = false;
+    persistDeliveringClears(runtime, [entry]);
   };
 
   /** Answer a pending UI question in the child and record the resolution. */
@@ -1654,6 +1692,10 @@ export function startFleet(options: StartFleetOptions): Promise<FleetHandle> {
         transcripts.load(name) as TranscriptEntry[],
         mapped
       ).slice(-50);
+      // Journaled delivering:true is sticky across boot unless we rewrite
+      // it: entries not in the pending journal already settled or were
+      // abandoned (timeout / unclean death). Clear them now and persist.
+      sweepDelivering(runtime);
       const lastEntry = runtime.transcript.at(-1);
       // Issue 140: a marker left behind means a turn died at daemon restart.
       // Re-drive it once and tell every waiting handoff source — the old
@@ -1735,7 +1777,7 @@ export function startFleet(options: StartFleetOptions): Promise<FleetHandle> {
           );
           runtime.activeDeliveryId = null;
           pendingStore.remove(name, message.id);
-          if (target) target.delivering = false;
+          markNotDelivering(runtime, target);
           log(`[${name}] replayed pending message (id ${message.id})`);
         } catch {
           // Keep it journalled; the next spawn retries.
@@ -1784,11 +1826,9 @@ export function startFleet(options: StartFleetOptions): Promise<FleetHandle> {
             const delivered = runtime.transcript.find(
               (candidate) => candidate.id === head.id
             );
-            if (delivered) {
-              delivered.delivering = false;
-              emit({ type: "append", bot: botName, entry: delivered });
-            }
+            if (delivered) markNotDelivering(runtime, delivered);
           }
+          sweepDelivering(runtime);
           emitRoster();
         }
         return;
@@ -1819,10 +1859,7 @@ export function startFleet(options: StartFleetOptions): Promise<FleetHandle> {
             (candidate) => candidate.id === runtime.activeDeliveryId
           );
           runtime.activeDeliveryId = null;
-          if (accepted?.delivering) {
-            accepted.delivering = false;
-            emit({ type: "append", bot: botName, entry: accepted });
-          }
+          markNotDelivering(runtime, accepted);
         }
         // Issue 148: replayed journal entries have no activeDeliveryId (it
         // died with the old daemon) — clear their delivering flags by id so
@@ -1832,10 +1869,7 @@ export function startFleet(options: StartFleetOptions): Promise<FleetHandle> {
             const replayed = runtime.transcript.find(
               (candidate) => candidate.id === id
             );
-            if (replayed?.delivering) {
-              replayed.delivering = false;
-              emit({ type: "append", bot: botName, entry: replayed });
-            }
+            markNotDelivering(runtime, replayed);
           }
           runtime.replayDeliveryIds.clear();
         }
@@ -2175,6 +2209,10 @@ export function startFleet(options: StartFleetOptions): Promise<FleetHandle> {
         void maybeCompact(runtime, forceNext ? { force: true } : {}).catch(
           () => {}
         );
+        // Issue 149 claimed settle reconciles timeout leftovers — it did
+        // not. Pending follow-ups stay delivering; everything else clears
+        // and is rewritten to the journal.
+        sweepDelivering(runtime, { settled: true });
         return;
       }
       case "ui_request": {
@@ -2274,6 +2312,7 @@ export function startFleet(options: StartFleetOptions): Promise<FleetHandle> {
           .catch(() => {});
       }
     }
+    sweepDelivering(runtime);
     emitRoster();
     log(`[${runtime.config.name}] exited (code=${code} signal=${signal})`);
     if (runtime.stopping) return;
@@ -2392,10 +2431,13 @@ export function startFleet(options: StartFleetOptions): Promise<FleetHandle> {
       runtime.activeDeliveryId = entry.id;
       await session.prompt(injectRules(runtime, text), behavior, images);
       runtime.activeDeliveryId = null;
-      entry.delivering = false;
-      emit({ type: "append", bot: runtime.config.name, entry });
+      markNotDelivering(runtime, entry);
     } catch (error) {
-      runtime.activeDeliveryId = null;
+      // Keep activeDeliveryId on rpc_prompt_timeout (issue 149 UNKNOWN):
+      // agent_start / settle still need the id. Nulled here, those events
+      // cannot clear the flag and it sticks forever.
+      if (classifyFailure(String(error)) !== "rpc_prompt_timeout")
+        runtime.activeDeliveryId = null;
       // Fresh-bot boot race: the agent can reject plain prompts while its first
       // turn is still settling. One followUp queues behind it; genuine failures
       // (offline, provider errors) still throw to the caller.
@@ -2678,14 +2720,12 @@ export function startFleet(options: StartFleetOptions): Promise<FleetHandle> {
           if (reason === "turn_in_flight") {
             // Issue 50: busy is never runtime_offline — reject distinctly and
             // visibly (the entry is marked failed, not half-delivered).
-            entry.delivering = false;
             entry.deliveryError = "turn_in_flight";
-            emit({ type: "append", bot: name, entry });
+            markNotDelivering(runtime, entry);
             return { status: 409, body: { error: "turn_in_flight" } };
           }
-          entry.delivering = false;
           entry.deliveryError = reason;
-          emit({ type: "append", bot: name, entry });
+          markNotDelivering(runtime, entry);
           return { status: 503, body: { error: reason } };
         }
       },
@@ -2838,6 +2878,12 @@ export function startFleet(options: StartFleetOptions): Promise<FleetHandle> {
     }
   }, 30_000);
   keepalive.unref?.();
+  // Idle fleets never settle — a 30s sweep expires stale delivering so
+  // Atlas cannot sit on forever-true operator bubbles.
+  const deliveringSweep = setInterval(() => {
+    for (const runtime of runtimes.values()) sweepDelivering(runtime);
+  }, 30_000);
+  deliveringSweep.unref?.();
 
   httpServer.on("error", (error: Error) => {
     const message =
@@ -3049,6 +3095,7 @@ export function startFleet(options: StartFleetOptions): Promise<FleetHandle> {
           if (reconcileTimer) clearTimeout(reconcileTimer);
           schedulerTimer.unref?.();
           clearInterval(schedulerTimer);
+          clearInterval(deliveringSweep);
           for (const watcher of personaWatchers.values()) watcher.close();
           for (const runtime of runtimes.values()) {
             runtime.stopping = true;
@@ -3251,6 +3298,27 @@ function buildHttpServer(deps: ServerDeps): Hono {
       };
     });
     return context.json({ dir: deps.fleet.dir, bots });
+  });
+
+  app.get("/api/health", (context) => {
+    const now = Date.now();
+    const verdict = evaluateFleetHealth(
+      [...deps.runtimes.values()].map((runtime) => ({
+        name: runtime.config.name,
+        transcript: runtime.transcript,
+        context: {
+          inputTokens: runtime.inputTokens ?? null,
+          contextWindow: runtime.contextWindow ?? null,
+          overWindow:
+            runtime.inputTokens !== undefined &&
+            runtime.contextWindow !== undefined &&
+            runtime.inputTokens > runtime.contextWindow,
+          fill: runtime.fill ?? null,
+        },
+      })),
+      { now }
+    );
+    return context.json(verdict, verdict.ok ? 200 : 503);
   });
 
   app.get("/api/bots/:name/context", (context) => {

--- a/packages/pi-tidy-bots/src/delivering.ts
+++ b/packages/pi-tidy-bots/src/delivering.ts
@@ -1,0 +1,90 @@
+/**
+ * Transcript `delivering` lifecycle (issue 74 + sticky-flag P0).
+ *
+ * `delivering:true` means "not yet accepted by the child" (queued follow-up
+ * or the accept-ack window). It must never stay true forever:
+ *   - agent_start / turn_start clear the matching entry
+ *   - settle / idle+empty-pending clear leftovers
+ *   - age ≥ STALE expires even an unknown timeout (issue 149)
+ *
+ * Journal appends write the flag once; callers must persist clears via
+ * `transcripts.save` or the next boot rehydrates forever-true bubbles.
+ */
+
+/** Matches the prompt-class guard — a flag older than this is sticky. */
+export const DEFAULT_STALE_DELIVERING_MS = 10 * 60_000;
+
+export interface DeliveringFlag {
+  id: string;
+  delivering?: boolean;
+  ts: string;
+}
+
+export function deliveringAgeMs(entry: { ts: string }, now: number): number {
+  const ts = Date.parse(entry.ts);
+  if (Number.isNaN(ts)) return Number.POSITIVE_INFINITY;
+  return Math.max(0, now - ts);
+}
+
+export function isStaleDelivering(
+  entry: DeliveringFlag,
+  now: number,
+  maxAgeMs: number = DEFAULT_STALE_DELIVERING_MS
+): boolean {
+  return entry.delivering === true && deliveringAgeMs(entry, now) >= maxAgeMs;
+}
+
+export function listStaleDelivering<T extends DeliveringFlag>(
+  entries: readonly T[],
+  now: number,
+  maxAgeMs: number = DEFAULT_STALE_DELIVERING_MS
+): T[] {
+  return entries.filter((entry) => isStaleDelivering(entry, now, maxAgeMs));
+}
+
+export interface ReconcileDeliveringOptions {
+  now?: number;
+  pendingIds?: Iterable<string>;
+  activeDeliveryId?: string | null;
+  streaming?: boolean;
+  /** True at agent_settled / interrupted-turn recovery — queued follow-ups stay. */
+  settled?: boolean;
+  maxAgeMs?: number;
+}
+
+/**
+ * Clear sticky `delivering` flags in place. Returns the entries that flipped.
+ *
+ * Keep:
+ *   - pending-journal ids (queued follow-ups; turn_start pops them)
+ *   - the accept-window id until settle or stale (issue 149 unknown timeout)
+ * Expire:
+ *   - any flag older than maxAgeMs
+ *   - non-pending leftovers once the turn settled or the child is idle
+ */
+export function reconcileDelivering<T extends DeliveringFlag>(
+  entries: T[],
+  opts: ReconcileDeliveringOptions = {}
+): T[] {
+  const now = opts.now ?? Date.now();
+  const pending = new Set(opts.pendingIds ?? []);
+  const maxAgeMs = opts.maxAgeMs ?? DEFAULT_STALE_DELIVERING_MS;
+  const cleared: T[] = [];
+  for (const entry of entries) {
+    if (entry.delivering !== true) continue;
+    const queued = pending.has(entry.id);
+    const accepting = entry.id === opts.activeDeliveryId;
+    if (isStaleDelivering(entry, now, maxAgeMs)) {
+      entry.delivering = false;
+      cleared.push(entry);
+      continue;
+    }
+    if (queued) continue;
+    if (accepting && !opts.settled) continue;
+    if (opts.settled || !opts.streaming) {
+      entry.delivering = false;
+      cleared.push(entry);
+    }
+  }
+  return cleared;
+}

--- a/packages/pi-tidy-bots/src/events.ts
+++ b/packages/pi-tidy-bots/src/events.ts
@@ -15,6 +15,7 @@ import {
 import { randomUUID } from "node:crypto";
 import { TurnPartsAccumulator } from "./turnparts.ts";
 import { stripActionMarkers } from "./actions.ts";
+import { reconcileDelivering } from "./delivering.ts";
 import type { BotRuntime, TranscriptEntry, UiRequestView } from "./daemon.ts";
 import type { PendingStore } from "./pending.ts";
 import type { BotConfig, ToolOutputMode } from "./config.ts";
@@ -117,10 +118,17 @@ export function createRpcEventHandler(
             const delivered = runtime.transcript.find(
               (candidate) => candidate.id === head.id
             );
-            if (delivered) {
+            if (delivered?.delivering) {
               delivered.delivering = false;
               ctx.emit({ type: "append", bot: botName, entry: delivered });
             }
+          }
+          for (const leftover of reconcileDelivering(runtime.transcript, {
+            pendingIds: ctx.pendingStore.load(botName).map((m) => m.id),
+            activeDeliveryId: runtime.activeDeliveryId,
+            streaming: runtime.session?.streaming === true,
+          })) {
+            ctx.emit({ type: "append", bot: botName, entry: leftover });
           }
           ctx.emitRoster();
         }
@@ -453,6 +461,14 @@ export function createRpcEventHandler(
         void ctx
           .maybeCompact(runtime, forceNext ? { force: true } : {})
           .catch(() => {});
+        for (const leftover of reconcileDelivering(runtime.transcript, {
+          pendingIds: ctx.pendingStore.load(botName).map((m) => m.id),
+          activeDeliveryId: runtime.activeDeliveryId,
+          streaming: runtime.session?.streaming === true,
+          settled: true,
+        })) {
+          ctx.emit({ type: "append", bot: botName, entry: leftover });
+        }
         return;
       }
       case "ui_request": {

--- a/packages/pi-tidy-bots/src/health-probe.ts
+++ b/packages/pi-tidy-bots/src/health-probe.ts
@@ -1,0 +1,267 @@
+/**
+ * Fail-closed fleet health verdict. Used by `pi-tidy-bots health` and the
+ * packaged `scripts/health-probe.sh`. Atlas's rook-tree copy at
+ * `bots/atlas/health-probe.sh` is not this repo — Foreman should point it
+ * here.
+ */
+import { pathToFileURL } from "node:url";
+import {
+  DEFAULT_STALE_DELIVERING_MS,
+  deliveringAgeMs,
+  listStaleDelivering,
+  type DeliveringFlag,
+} from "./delivering.ts";
+
+export interface ContextSnapshot {
+  inputTokens?: number | null;
+  contextWindow?: number | null;
+  overWindow?: boolean;
+  fill?: number | null;
+}
+
+export interface BotHealthInput {
+  name: string;
+  transcript: DeliveringFlag[];
+  context?: ContextSnapshot;
+}
+
+export interface StaleDeliveringReport {
+  id: string;
+  ts: string;
+  ageMs: number;
+}
+
+export interface BotHealthVerdict {
+  name: string;
+  ok: boolean;
+  staleDelivering: StaleDeliveringReport[];
+  overBudget: boolean;
+  inputTokens: number | null;
+  contextWindow: number | null;
+  reasons: string[];
+}
+
+export interface FleetHealthVerdict {
+  ok: boolean;
+  staleDeliveringMs: number;
+  tokenBudget?: number;
+  bots: BotHealthVerdict[];
+}
+
+export interface EvaluateFleetHealthOptions {
+  now?: number;
+  staleDeliveringMs?: number;
+  tokenBudget?: number;
+}
+
+export function contextOverBudget(
+  context: ContextSnapshot | undefined,
+  tokenBudget?: number
+): boolean {
+  if (!context) return false;
+  if (context.overWindow === true) return true;
+  if (context.fill !== undefined && context.fill !== null && context.fill >= 1)
+    return true;
+  const tokens = context.inputTokens;
+  if (tokens == null || !Number.isFinite(tokens)) return false;
+  const budget =
+    tokenBudget ??
+    (context.contextWindow != null && context.contextWindow > 0
+      ? context.contextWindow
+      : undefined);
+  return budget != null && tokens > budget;
+}
+
+export function evaluateBotHealth(
+  bot: BotHealthInput,
+  opts: EvaluateFleetHealthOptions = {}
+): BotHealthVerdict {
+  const now = opts.now ?? Date.now();
+  const staleMs = opts.staleDeliveringMs ?? DEFAULT_STALE_DELIVERING_MS;
+  const stale = listStaleDelivering(bot.transcript, now, staleMs).map(
+    (entry) => ({
+      id: entry.id,
+      ts: entry.ts,
+      ageMs: deliveringAgeMs(entry, now),
+    })
+  );
+  const overBudget = contextOverBudget(bot.context, opts.tokenBudget);
+  const reasons: string[] = [];
+  if (stale.length > 0)
+    reasons.push(
+      `${stale.length} transcript delivering:true older than ${staleMs}ms`
+    );
+  if (overBudget) reasons.push("context over budget");
+  return {
+    name: bot.name,
+    ok: stale.length === 0 && !overBudget,
+    staleDelivering: stale,
+    overBudget,
+    inputTokens: bot.context?.inputTokens ?? null,
+    contextWindow: bot.context?.contextWindow ?? null,
+    reasons,
+  };
+}
+
+export function evaluateFleetHealth(
+  bots: BotHealthInput[],
+  opts: EvaluateFleetHealthOptions = {}
+): FleetHealthVerdict {
+  const verdicts = bots.map((bot) => evaluateBotHealth(bot, opts));
+  return {
+    ok: verdicts.every((bot) => bot.ok),
+    staleDeliveringMs: opts.staleDeliveringMs ?? DEFAULT_STALE_DELIVERING_MS,
+    ...(opts.tokenBudget !== undefined
+      ? { tokenBudget: opts.tokenBudget }
+      : {}),
+    bots: verdicts,
+  };
+}
+
+export async function probeFleetHealth(input: {
+  url: string;
+  bots?: string[];
+  token?: string;
+  staleDeliveringMs?: number;
+  tokenBudget?: number;
+  now?: number;
+  fetchImpl?: typeof fetch;
+}): Promise<FleetHealthVerdict> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const headers: Record<string, string> = {};
+  if (input.token) headers.authorization = `Bearer ${input.token}`;
+  const get = async (path: string): Promise<unknown> => {
+    const res = await fetchImpl(new URL(path, input.url).href, { headers });
+    if (!res.ok) throw new Error(`${path} -> ${res.status}`);
+    return res.json();
+  };
+
+  try {
+    const health = (await get("/api/health")) as FleetHealthVerdict & {
+      ok?: boolean;
+      bots?: BotHealthVerdict[];
+    };
+    if (health && Array.isArray(health.bots) && typeof health.ok === "boolean")
+      return health;
+  } catch {
+    // Pre-/api/health daemons: compose from transcript + context.
+  }
+
+  const roster = (await get("/api/fleet")) as {
+    bots?: { name: string }[];
+  };
+  const names =
+    input.bots && input.bots.length > 0
+      ? input.bots
+      : (roster.bots ?? []).map((bot) => bot.name);
+  const snapshots: BotHealthInput[] = [];
+  for (const name of names) {
+    const [transcriptBody, context] = await Promise.all([
+      get(`/api/bots/${encodeURIComponent(name)}/transcript`),
+      get(`/api/bots/${encodeURIComponent(name)}/context`).catch(
+        () => undefined
+      ),
+    ]);
+    const transcript = Array.isArray(transcriptBody)
+      ? transcriptBody
+      : ((transcriptBody as { transcript?: unknown })?.transcript ?? []);
+    snapshots.push({
+      name,
+      transcript: Array.isArray(transcript)
+        ? (transcript as DeliveringFlag[])
+        : [],
+      context: context as ContextSnapshot | undefined,
+    });
+  }
+  return evaluateFleetHealth(snapshots, {
+    now: input.now,
+    staleDeliveringMs: input.staleDeliveringMs,
+    tokenBudget: input.tokenBudget,
+  });
+}
+
+export function parseHealthProbeArgs(argv: string[]): {
+  url: string;
+  bots?: string[];
+  token?: string;
+  staleDeliveringMs?: number;
+  tokenBudget?: number;
+} {
+  const flags: Record<string, string> = {};
+  const positional: string[] = [];
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index] ?? "";
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+      const next = argv[index + 1];
+      if (next !== undefined && !next.startsWith("--")) {
+        flags[key] = next;
+        index++;
+      }
+    } else positional.push(arg);
+  }
+  const staleMin = flags["stale-min"];
+  const budget = flags["token-budget"];
+  return {
+    url: flags.url ?? positional[0] ?? "http://127.0.0.1:4317",
+    ...(flags.bot ? { bots: [flags.bot] } : {}),
+    ...(flags.token ? { token: flags.token } : {}),
+    ...(staleMin !== undefined
+      ? { staleDeliveringMs: Number(staleMin) * 60_000 }
+      : {}),
+    ...(budget !== undefined ? { tokenBudget: Number(budget) } : {}),
+  };
+}
+
+export async function runHealthProbeCli(
+  argv: string[],
+  io: {
+    fetchImpl?: typeof fetch;
+    log?: (line: string) => void;
+    error?: (line: string) => void;
+  } = {}
+): Promise<number> {
+  const args = parseHealthProbeArgs(argv);
+  if (
+    (args.staleDeliveringMs !== undefined &&
+      !Number.isFinite(args.staleDeliveringMs)) ||
+    (args.tokenBudget !== undefined && !Number.isFinite(args.tokenBudget))
+  ) {
+    (io.error ?? console.error)(
+      JSON.stringify({
+        ok: false,
+        error: "stale-min and token-budget must be numbers",
+      })
+    );
+    return 1;
+  }
+  try {
+    const verdict = await probeFleetHealth({
+      ...args,
+      fetchImpl: io.fetchImpl,
+    });
+    const sink = verdict.ok
+      ? (io.log ?? console.log)
+      : (io.error ?? console.error);
+    sink(JSON.stringify(verdict));
+    return verdict.ok ? 0 : 1;
+  } catch (error) {
+    (io.error ?? console.error)(
+      JSON.stringify({ ok: false, error: String(error) })
+    );
+    return 1;
+  }
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  runHealthProbeCli(process.argv.slice(2)).then(
+    (code) => process.exit(code),
+    (error) => {
+      console.error(JSON.stringify({ ok: false, error: String(error) }));
+      process.exit(1);
+    }
+  );
+}

--- a/packages/pi-tidy-bots/src/server.ts
+++ b/packages/pi-tidy-bots/src/server.ts
@@ -17,6 +17,7 @@ import {
 } from "./config.ts";
 import { DEFAULT_COMPACT_FALLBACK_MODEL } from "./daemon.ts";
 import { paginateTranscript } from "./transcripts.ts";
+import { evaluateFleetHealth } from "./health-probe.ts";
 import { versionPayload } from "./contract.ts";
 import type { BotRuntime } from "./daemon.ts";
 
@@ -464,6 +465,25 @@ export function buildHttpServer(deps: ServerDeps): Hono {
       };
     });
     return context.json({ dir: deps.fleet.dir, bots });
+  });
+
+  app.get("/api/health", (context) => {
+    const verdict = evaluateFleetHealth(
+      [...deps.runtimes.values()].map((runtime) => ({
+        name: runtime.config.name,
+        transcript: runtime.transcript,
+        context: {
+          inputTokens: runtime.inputTokens ?? null,
+          contextWindow: runtime.contextWindow ?? null,
+          overWindow:
+            runtime.inputTokens !== undefined &&
+            runtime.contextWindow !== undefined &&
+            runtime.inputTokens > runtime.contextWindow,
+          fill: runtime.fill ?? null,
+        },
+      }))
+    );
+    return context.json(verdict, verdict.ok ? 200 : 503);
   });
 
   app.get("/api/bots/:name/context", (context) => {

--- a/packages/pi-tidy-bots/test/delivering-reconcile.test.ts
+++ b/packages/pi-tidy-bots/test/delivering-reconcile.test.ts
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  DEFAULT_STALE_DELIVERING_MS,
+  reconcileDelivering,
+  isStaleDelivering,
+} from "../src/delivering.ts";
+import { createRpcEventHandler } from "../src/events.ts";
+import type { BotRuntime, TranscriptEntry } from "../src/daemon.ts";
+
+const now = Date.parse("2026-09-07T20:00:00.000Z");
+
+const entry = (id: string, ts: string, delivering = true): TranscriptEntry => ({
+  id,
+  role: "user",
+  origin: "operator",
+  text: id,
+  ts,
+  delivering,
+});
+
+test("stale delivering is older than the prompt-class window", () => {
+  const fresh = entry("a", new Date(now - 60_000).toISOString());
+  const stale = entry(
+    "b",
+    new Date(now - DEFAULT_STALE_DELIVERING_MS).toISOString()
+  );
+  assert.equal(isStaleDelivering(fresh, now), false);
+  assert.equal(isStaleDelivering(stale, now), true);
+});
+
+test("settle clears leftover delivering; pending follow-up stays", () => {
+  const stuck = entry("timeout-unknown", "2026-09-06T03:00:00.000Z");
+  const queued = entry("follow-up", "2026-09-07T19:59:00.000Z");
+  const cleared = reconcileDelivering([stuck, queued], {
+    now,
+    pendingIds: ["follow-up"],
+    settled: true,
+    streaming: false,
+  });
+  assert.equal(stuck.delivering, false);
+  assert.equal(queued.delivering, true);
+  assert.deepEqual(
+    cleared.map((e) => e.id),
+    ["timeout-unknown"]
+  );
+});
+
+test("idle + empty pending clears; accept-window id is kept until stale", () => {
+  const accepting = entry("active", new Date(now - 30_000).toISOString());
+  const orphan = entry("orphan", new Date(now - 45_000).toISOString());
+  reconcileDelivering([accepting, orphan], {
+    now,
+    activeDeliveryId: "active",
+    streaming: false,
+    pendingIds: [],
+  });
+  assert.equal(accepting.delivering, true, "issue 149 unknown window kept");
+  assert.equal(orphan.delivering, false, "no pending and not active → clear");
+});
+
+test("stale expires even the accept-window and queued flags", () => {
+  const aged = entry(
+    "active",
+    new Date(now - DEFAULT_STALE_DELIVERING_MS - 1).toISOString()
+  );
+  reconcileDelivering([aged], {
+    now,
+    activeDeliveryId: "active",
+    pendingIds: ["active"],
+    streaming: true,
+  });
+  assert.equal(aged.delivering, false, "never forever-true");
+});
+
+test("protocol: agent_settled clears timeout leftover not in pending", () => {
+  const leftover = entry("op-1", "2026-09-06T02:12:00.000Z");
+  const runtime = {
+    config: { name: "atlas" },
+    transcript: [leftover],
+    activeDeliveryId: null,
+    session: { streaming: false },
+    pendingFrom: [],
+    turnId: "turn-1",
+    turnParts: { concatText: () => "", snapshot: () => [] },
+    steps: [],
+    forceCompactNext: false,
+    emptyTurnStreak: 0,
+  } as unknown as BotRuntime;
+  const emitted: unknown[] = [];
+  const handler = createRpcEventHandler({
+    runtimes: new Map(),
+    fleetBots: () => [],
+    pendingStore: { load: () => [], remove: () => {} },
+    activeToolOutput: () => "off",
+    viewSteps: (steps) => steps,
+    computeFill: () => undefined,
+    log: () => {},
+    emit: (event) => emitted.push(event),
+    emitRoster: () => {},
+    touch: () => {},
+    appendTranscript: () => {},
+    resolveUi: () => {},
+    maybeCompact: async () => {},
+  });
+  handler(runtime, { kind: "agent_settled" });
+  assert.equal(leftover.delivering, false);
+  assert.ok(
+    emitted.some(
+      (event) =>
+        event &&
+        typeof event === "object" &&
+        (event as { type?: string }).type === "append" &&
+        (event as { entry?: { id?: string } }).entry?.id === "op-1"
+    ),
+    "cleared entry is appended so clients drop the spinner"
+  );
+});
+
+test(
+  "boot rewrite: journaled delivering:true not in pending is cleared and persisted",
+  { timeout: 45000 },
+  async () => {
+    const fleetDir = mkdtempSync(join(tmpdir(), "ptb-sticky-deliv-"));
+    const runner = new URL("./fixtures/rpc/streaming-pi.mjs", import.meta.url)
+      .pathname;
+    const handles: Array<{ stop(): Promise<void> }> = [];
+    try {
+      mkdirSync(join(fleetDir, "bots", "aa"), { recursive: true });
+      mkdirSync(join(fleetDir, ".fleet", "transcripts"), { recursive: true });
+      writeFileSync(join(fleetDir, "bots", "aa", "AGENTS.md"), "# aa\n");
+      writeFileSync(
+        join(fleetDir, "bots.toml"),
+        `[[bot]]\nname = "aa"\ndir = "bots/aa"\n`
+      );
+      writeFileSync(
+        join(fleetDir, ".fleet", "transcripts", "aa.jsonl"),
+        `${JSON.stringify({
+          id: "stuck-1",
+          role: "user",
+          origin: "operator",
+          text: "yesterday",
+          ts: "2026-09-06T02:12:00.000Z",
+          delivering: true,
+        })}\n`
+      );
+      const wrapper = join(fleetDir, "pi.sh");
+      writeFileSync(wrapper, `#!/bin/sh\nexec node ${runner}\n`);
+      spawnSync("chmod", ["+x", wrapper]);
+      const { startFleet } = await import("../src/daemon.ts");
+      const handle = await startFleet({
+        dir: fleetDir,
+        port: 0,
+        host: "127.0.0.1",
+        piBin: wrapper,
+        log: () => {},
+      });
+      handles.push(handle);
+      const base = `http://127.0.0.1:${handle.port}`;
+      const deadline = Date.now() + 20000;
+      let delivering: boolean | undefined = true;
+      while (Date.now() < deadline) {
+        const res = await fetch(`${base}/api/bots/aa/transcript`);
+        if (res.ok) {
+          const body = (await res.json()) as {
+            transcript: { id: string; delivering?: boolean }[];
+          };
+          const stuck = body.transcript.find((e) => e.id === "stuck-1");
+          if (stuck) {
+            delivering = stuck.delivering;
+            if (delivering !== true) break;
+          }
+        }
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      assert.notEqual(
+        delivering,
+        true,
+        "boot sweep persists a clear for journaled leftovers"
+      );
+    } finally {
+      await Promise.all(handles.map((h) => h.stop().catch(() => {})));
+      rmSync(fleetDir, { recursive: true, force: true });
+    }
+  }
+);

--- a/packages/pi-tidy-bots/test/health-probe.test.ts
+++ b/packages/pi-tidy-bots/test/health-probe.test.ts
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+  evaluateFleetHealth,
+  parseHealthProbeArgs,
+  probeFleetHealth,
+  runHealthProbeCli,
+} from "../src/health-probe.ts";
+import { DEFAULT_STALE_DELIVERING_MS } from "../src/delivering.ts";
+
+const now = Date.parse("2026-09-07T20:00:00.000Z");
+const staleTs = new Date(
+  now - DEFAULT_STALE_DELIVERING_MS - 1000
+).toISOString();
+const freshTs = new Date(now - 30_000).toISOString();
+
+test("probe fails closed on stale delivering", () => {
+  const verdict = evaluateFleetHealth(
+    [
+      {
+        name: "atlas",
+        transcript: [
+          {
+            id: "op-1",
+            ts: staleTs,
+            delivering: true,
+          },
+        ],
+        context: {
+          inputTokens: 1000,
+          contextWindow: 128000,
+          overWindow: false,
+        },
+      },
+    ],
+    { now }
+  );
+  assert.equal(verdict.ok, false);
+  assert.equal(verdict.bots[0]?.staleDelivering.length, 1);
+  assert.match(verdict.bots[0]?.reasons[0] ?? "", /delivering:true/);
+});
+
+test("probe fails closed on context over budget", () => {
+  const overWindow = evaluateFleetHealth(
+    [
+      {
+        name: "atlas",
+        transcript: [],
+        context: {
+          inputTokens: 273000,
+          contextWindow: 272000,
+          overWindow: true,
+        },
+      },
+    ],
+    { now }
+  );
+  assert.equal(overWindow.ok, false);
+  assert.equal(overWindow.bots[0]?.overBudget, true);
+
+  const explicitBudget = evaluateFleetHealth(
+    [
+      {
+        name: "atlas",
+        transcript: [],
+        context: {
+          inputTokens: 273000,
+          contextWindow: 1_000_000,
+          overWindow: false,
+        },
+      },
+    ],
+    { now, tokenBudget: 200000 }
+  );
+  assert.equal(explicitBudget.ok, false);
+});
+
+test("fresh delivering and in-budget context pass", () => {
+  const verdict = evaluateFleetHealth(
+    [
+      {
+        name: "atlas",
+        transcript: [{ id: "live", ts: freshTs, delivering: true }],
+        context: {
+          inputTokens: 12000,
+          contextWindow: 128000,
+          overWindow: false,
+        },
+      },
+    ],
+    { now }
+  );
+  assert.equal(verdict.ok, true);
+});
+
+test("probeFleetHealth composes transcript+context when /api/health is absent", async () => {
+  const paths: string[] = [];
+  const fetchImpl = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    paths.push(new URL(url).pathname);
+    if (url.includes("/api/health")) return new Response("no", { status: 404 });
+    if (url.includes("/api/fleet"))
+      return Response.json({ bots: [{ name: "atlas" }] });
+    if (url.includes("/transcript"))
+      return Response.json({
+        transcript: [{ id: "op-1", ts: staleTs, delivering: true, text: "x" }],
+      });
+    if (url.includes("/context"))
+      return Response.json({
+        inputTokens: 273000,
+        contextWindow: 272000,
+        overWindow: true,
+      });
+    return new Response("no", { status: 404 });
+  }) as typeof fetch;
+  const verdict = await probeFleetHealth({
+    url: "http://127.0.0.1:4317",
+    now,
+    fetchImpl,
+  });
+  assert.equal(verdict.ok, false);
+  assert.ok(verdict.bots[0]?.staleDelivering.length === 1);
+  assert.equal(verdict.bots[0]?.overBudget, true);
+  assert.ok(paths.includes("/api/health"));
+  assert.ok(paths.includes("/api/bots/atlas/transcript"));
+});
+
+test("runHealthProbeCli exits 1 on stale delivering (script contract)", async () => {
+  const fetchImpl = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes("/api/health"))
+      return Response.json({
+        ok: false,
+        staleDeliveringMs: DEFAULT_STALE_DELIVERING_MS,
+        bots: [
+          {
+            name: "atlas",
+            ok: false,
+            staleDelivering: [{ id: "op-1", ts: staleTs, ageMs: 86_400_000 }],
+            overBudget: false,
+            inputTokens: 273000,
+            contextWindow: 1_000_000,
+            reasons: ["1 transcript delivering:true older than 600000ms"],
+          },
+        ],
+      });
+    return new Response("no", { status: 404 });
+  }) as typeof fetch;
+  const lines: string[] = [];
+  const code = await runHealthProbeCli(["http://127.0.0.1:4317"], {
+    fetchImpl,
+    error: (line) => lines.push(line),
+    log: (line) => lines.push(line),
+  });
+  assert.equal(code, 1);
+  assert.match(lines.join("\n"), /delivering:true/);
+});
+
+test("parseHealthProbeArgs reads url/bot/stale-min/token-budget", () => {
+  assert.deepEqual(
+    parseHealthProbeArgs([
+      "--url",
+      "http://127.0.0.1:9",
+      "--bot",
+      "atlas",
+      "--stale-min",
+      "5",
+      "--token-budget",
+      "200000",
+    ]),
+    {
+      url: "http://127.0.0.1:9",
+      bots: ["atlas"],
+      staleDeliveringMs: 5 * 60_000,
+      tokenBudget: 200000,
+    }
+  );
+});
+
+test("packaged health-probe.sh is executable and fail-closed", () => {
+  const script = fileURLToPath(
+    new URL("../scripts/health-probe.sh", import.meta.url)
+  );
+  const probe = spawnSync("bash", [script, "http://127.0.0.1:1"], {
+    encoding: "utf8",
+    timeout: 15000,
+  });
+  assert.notEqual(probe.status, 0, "unreachable daemon must not exit 0");
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Cause

Atlas operator bubbles stuck `delivering:true` with empty pending/inflight. Three holes in the transcript lifecycle:

1. **Issue 149 timeout race.** `rpc_prompt_timeout` kept `delivering:true` (“settle will reconcile”) but `deliver()` nulled `activeDeliveryId` in the same catch. `agent_start` only clears by that id; `agent_settled` never cleared leftovers. After a 10-minute prompt-class timeout the flag is orphaned forever.
2. **Journal never rewritten.** `appendTranscript` persists `delivering:true` once. Clears were in-memory + WS only (`transcripts.save` is used for completion summaries). Boot `mergeTranscriptHistory` rehydrates forever-true bubbles. Issue 148 only cleared *replayed pending* ids — not already-settled leftovers. Matches “pending/inflight empty, ~9 operator messages still spinning.”
3. **Health probe miss.** No `/api/health`. Roster/context do not expose sticky delivering. `bots/atlas/health-probe.sh` is **not in this repo** (rook fleet tree). It exits 0 on a live API + token count; it does not fail on stale `delivering:true` or over-budget context (~273k).

## Fix

- `reconcileDelivering`: expire stale flags (≥10 min, same as prompt-class timeout); clear non-pending leftovers on settle / idle; keep accept-window id until settle or stale (issue 149 UNKNOWN).
- Daemon: persist every clear via `transcripts.save`; keep `activeDeliveryId` on timeout; sweep on boot, `turn_start`, `agent_settled`, child exit, and a 30s idle interval.
- `GET /api/health` (200/503) + `pi-tidy-bots health` + packaged `packages/pi-tidy-bots/scripts/health-probe.sh`. Fail-closed on stale delivering **or** context over budget. Composes from transcript+context when `/api/health` is absent (old daemons).

### Foreman — rook fleet probe

Source of truth is now this package. The live copy is **not here**:

- **Path:** rook fleet tree `bots/atlas/health-probe.sh` (typically `<fleetDir>/bots/atlas/health-probe.sh`, e.g. wherever Atlas’s `AGENTS.md` lives on rook).
- **Patch:** replace the body with a wrapper to the packaged probe (do not keep a local evaluator):

```bash
#!/usr/bin/env bash
set -euo pipefail
# Fail-closed: stale delivering:true OR context over budget.
exec pi-tidy-bots health "${PTB_HEALTH_URL:-http://127.0.0.1:4317}" --bot atlas "$@"
```

Or exec the packaged script after install. Until that wrapper lands, prod `:4317` will keep answering “clear.”

## Proof

```bash
cd packages/pi-tidy-bots
node --import tsx --test --test-concurrency=1 \
  test/delivering-reconcile.test.ts test/health-probe.test.ts test/delivering.test.ts
npx tsc --noEmit
```

**Pass (this revision):** 13 new + 1 existing delivering = 14 pass; `tsc --noEmit` pass.

| Test | Result |
|---|---|
| settle clears leftover; pending follow-up stays | pass |
| idle+empty pending clears; accept-window kept until stale | pass |
| stale expires even accept-window/queued | pass |
| protocol `agent_settled` clears timeout leftover | pass |
| boot rewrite persists journaled leftover clear | pass |
| probe fails closed on stale delivering | pass |
| probe fails closed on over-budget / overWindow (273k) | pass |
| fresh delivering + in-budget pass | pass |
| compose transcript+context when `/api/health` 404 | pass |
| CLI exits 1 on stale delivering | pass |
| `health-probe.sh` fail-closed on unreachable daemon | pass |
| existing issue-74 mid-turn / queued follow-up | pass |

## Unverified

- No live Hermes smoke. No prod `:4317` writes/restarts (per brief). Sticky Atlas rows will clear on next daemon boot/sweep **after this lands**; not cleared in prod by this PR.
- Full workspace `npm test` was not green in this VM: many gateway/Python/SQLite ownership tests failed with `GatewayStartupOwnershipError` / `unsupported_sqlite` (environment; not exercised by this change). Re-run on a machine with the supported SQLite engine + Python SDK.
- Rook `bots/atlas/health-probe.sh` cannot be patched from this repo.

Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-050a57f1-f317-4f93-a4be-f28bff2f45c8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-050a57f1-f317-4f93-a4be-f28bff2f45c8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

