### PR TITLE
fix(pi-tidy-bots): Hermes session continuity across restart (#200)

### DIFF
--- a/packages/pi-tidy-bots/backends/hermes/adapter.ts
+++ b/packages/pi-tidy-bots/backends/hermes/adapter.ts
@@ -19,8 +19,8 @@ import {
   type HermesRuntime,
 } from "./runtime.ts";
 
-// Fresh guarded ACP sessions only. Native continuity, media and
-// non-pipe worker profiles require their remaining conformance work.
+// Guarded ACP sessions. Load continuity is SessionDB checkpoint-v1 after a
+// proven turn — not profile/sessions files, media, or non-pipe workers.
 export const HERMES_CAPABILITIES: CapabilityDescriptor = {
   input: {
     text: true,

--- a/packages/pi-tidy-bots/backends/hermes/history.py
+++ b/packages/pi-tidy-bots/backends/hermes/history.py
@@ -35,6 +35,11 @@ _ACCOUNTING_ROW_FIELDS = frozenset((
 # a turn is result["messages"] without those keys. Treating them as
 # conversation identity left every first-turn checkpoint unavailable, so
 # reload failed as session_open:native_startup_history / continuity_unverified.
+#
+# Live build_assistant_message always stamps reasoning=None. SessionDB
+# _rows_to_conversation omits falsy optional fields, so the same turn
+# projected from state.db has no reasoning key. None vs omit is not
+# conversation identity.
 _PERSISTENCE_BOOKKEEPING_KEYS = frozenset((
     "_db_persisted", "_row_id", "_compressed_summary", "timestamp",
 ))
@@ -57,6 +62,7 @@ def _conversation_identity(messages):
             key: value for key, value in message.items()
             if key not in _PERSISTENCE_BOOKKEEPING_KEYS
             and not (isinstance(key, str) and key.startswith("_"))
+            and value is not None
         })
     return identity
 

--- a/packages/pi-tidy-bots/backends/hermes/history.py
+++ b/packages/pi-tidy-bots/backends/hermes/history.py
@@ -128,27 +128,51 @@ def verify_history_checkpoint(manager, state, expected):
     return actual
 
 
+def _sessiondb_state(manager, sid, cwd, database_path):
+    """Project SessionDB into the same state shape load already proves."""
+    path = Path(database_path)
+    if path.is_symlink() or not path.is_file() or path.stat().st_size < 1:
+        raise HistoryUnavailable()
+    if getattr(manager, "_db_instance", None) is None:
+        manager._get_db()
+    db = getattr(manager, "_db_instance", None)
+    if db is None:
+        raise HistoryUnavailable()
+    row = db.get_session(sid)
+    if not isinstance(row, dict):
+        raise HistoryUnavailable()
+    metadata = json.loads(row["model_config"])
+    native = SimpleNamespace(session_id=sid, model=row.get("model") or "",
+                             **{field: metadata[field] for field in ("provider", "base_url", "api_mode") if field in metadata})
+    return SimpleNamespace(session_id=sid, agent=native,
+                           cwd=cwd, model=row.get("model") or "", is_running=False, queued_prompts=[],
+                           history=db.get_messages_as_conversation(sid, repair_alternation=False))
+
+
 def prepare_history_load(manager, sid, cwd, expected, database_path):
     """Prove persisted input before native restore can construct an agent or repair history."""
     try:
-        path = Path(database_path)
-        if path.is_symlink() or not path.is_file() or path.stat().st_size < 1:
+        if expected.get("sessionId") != sid:
             raise HistoryUnavailable()
-        if getattr(manager, "_db_instance", None) is None:
-            manager._get_db()
-        db = getattr(manager, "_db_instance", None)
-        if db is None or expected.get("sessionId") != sid:
-            raise HistoryUnavailable()
-        row = db.get_session(sid)
-        if not isinstance(row, dict):
-            raise HistoryUnavailable()
-        metadata = json.loads(row["model_config"])
-        native = SimpleNamespace(session_id=sid, model=row.get("model") or "",
-                                 **{field: metadata[field] for field in ("provider", "base_url", "api_mode") if field in metadata})
-        state = SimpleNamespace(session_id=sid, agent=native,
-                                cwd=cwd, model=row.get("model") or "", is_running=False, queued_prompts=[],
-                                history=db.get_messages_as_conversation(sid, repair_alternation=False))
-        return verify_history_checkpoint(manager, state, expected)
+        return verify_history_checkpoint(manager, _sessiondb_state(manager, sid, cwd, database_path), expected)
+    except Exception:
+        raise HistoryUnavailable() from None
+
+
+def persist_history_checkpoint(manager, sid, cwd, store, database_path):
+    """Publish a SessionDB-backed checkpoint so reload can prove continuity after an unfinished turn.
+
+    Live ACP history is only available after prompt() returns. Long CoS turns
+    that die as plugin_eof never reach that save. SessionDB is updated earlier
+    and remains readable after the native child exits; checkpoint from that
+    row, not from the live agent.
+    """
+    if store is None:
+        raise HistoryUnavailable()
+    try:
+        checkpoint = history_checkpoint(manager, _sessiondb_state(manager, sid, cwd, database_path))
+        store.save(checkpoint)
+        return checkpoint
     except Exception:
         raise HistoryUnavailable() from None
 

--- a/packages/pi-tidy-bots/backends/hermes/native_guard.py
+++ b/packages/pi-tidy-bots/backends/hermes/native_guard.py
@@ -141,7 +141,7 @@ class ApprovalGuard:
 
 
 def guarded_agent(base, guard, prompt_response, worker_type, fleet=None, history_proof=None, history_store=None,
-                  history_prepare=None, history_verify=None):
+                  history_prepare=None, history_verify=None, history_persist=None):
     class GuardedHermesACPAgent(base):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
@@ -317,6 +317,18 @@ def guarded_agent(base, guard, prompt_response, worker_type, fleet=None, history
             result.field_meta = extra
             return result
 
+        def _tidy_persist_history(self, session_id):
+            if history_store is None or history_persist is None:
+                return
+            state = self._tidy_live_state(session_id)
+            if state is None:
+                return
+            try:
+                history_persist(self.session_manager, session_id, state.cwd, history_store,
+                                guard.profile / "state.db")
+            except Exception:
+                pass
+
         async def new_session(self, *args, **kwargs):
             try:
                 guard.check()
@@ -361,6 +373,7 @@ def guarded_agent(base, guard, prompt_response, worker_type, fleet=None, history
                     raise ApprovalPolicyUnavailable()
                 modes.available_modes = [mode for mode in modes.available_modes if mode.id == "default"]
             self._tidy_created_sessions.add(result.session_id)
+            self._tidy_persist_history(result.session_id)
             return result
 
         async def prompt(self, prompt, session_id, **kwargs):
@@ -436,6 +449,9 @@ def guarded_agent(base, guard, prompt_response, worker_type, fleet=None, history
                     history_store.invalidate(session_id)
                 except Exception:
                     return refuse("continuity_unavailable")
+                # Publish SessionDB's current row immediately so a mid-turn
+                # plugin_eof still has a loadable checkpoint.
+                self._tidy_persist_history(session_id)
             evidence = {"started": False, "settled": False, "failed": False,
                         "interrupted": False}
             had_override = "run_conversation" in vars(native)
@@ -463,6 +479,7 @@ def guarded_agent(base, guard, prompt_response, worker_type, fleet=None, history
                     raise
                 finally:
                     evidence["settled"] = True
+                    self._tidy_persist_history(session_id)
 
             self._tidy_active_prompt = True
             self._tidy_worker_session = session_id
@@ -600,6 +617,7 @@ def guarded_agent(base, guard, prompt_response, worker_type, fleet=None, history
                     proof["fleetTools"] = "native-mcp-v1"
                 result.field_meta = {**(result.field_meta or {}), "tidy": proof}
                 self._tidy_created_sessions.add(session_id)
+                self._tidy_persist_history(session_id)
                 return result
             finally:
                 self._tidy_loading_session = None
@@ -685,7 +703,7 @@ def main():
     spec.loader.exec_module(history)
     history_store = history.HistoryStore(directory(args.checkpoint_dir), args.binding_id) if args.checkpoint_dir else None
     agent = guarded_agent(HermesACPAgent, guard, PromptResponse, owned.NativeWorkers, fleet, history.history_checkpoint, history_store,
-                          history.prepare_history_load, history.verify_history_checkpoint)()
+                          history.prepare_history_load, history.verify_history_checkpoint, history.persist_history_checkpoint)()
     if fleet is not None:
         fleet_module.install_fleet_identity(mcp_tool, ClientSession, approval, agent._tidy_fleet_scope)
     from tools import process_registry
@@ -696,11 +714,15 @@ def main():
             await acp.run_agent(agent, use_unstable_protocol=True)
         finally:
             try:
-                if agent._tidy_workers is not None:
-                    await agent._tidy_workers.close()
+                for sid in list(agent._tidy_created_sessions):
+                    agent._tidy_persist_history(sid)
             finally:
-                if history_store is not None:
-                    history_store.close()
+                try:
+                    if agent._tidy_workers is not None:
+                        await agent._tidy_workers.close()
+                finally:
+                    if history_store is not None:
+                        history_store.close()
 
     asyncio.run(run())
 

--- a/packages/pi-tidy-bots/backends/hermes/native_guard.py
+++ b/packages/pi-tidy-bots/backends/hermes/native_guard.py
@@ -146,6 +146,7 @@ def guarded_agent(base, guard, prompt_response, worker_type, fleet=None, history
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
             self._tidy_created_sessions = set()
+            self._tidy_session_cwds = {}
             self._tidy_active_prompt = False
             self._tidy_loading_session = None
             self._tidy_update_tickets = None
@@ -321,10 +322,15 @@ def guarded_agent(base, guard, prompt_response, worker_type, fleet=None, history
             if history_store is None or history_persist is None:
                 return
             state = self._tidy_live_state(session_id)
-            if state is None:
+            if state is not None and isinstance(getattr(state, "cwd", None), str):
+                self._tidy_session_cwds[session_id] = state.cwd
+            cwd = self._tidy_session_cwds.get(session_id)
+            if not isinstance(cwd, str) or not cwd:
                 return
             try:
-                history_persist(self.session_manager, session_id, state.cwd, history_store,
+                # SessionDB may fill provider/base_url after session/new.
+                # Teardown must still publish even if the live map was evicted.
+                history_persist(self.session_manager, session_id, cwd, history_store,
                                 guard.profile / "state.db")
             except Exception:
                 pass

--- a/packages/pi-tidy-bots/src/gateway/application.ts
+++ b/packages/pi-tidy-bots/src/gateway/application.ts
@@ -307,14 +307,15 @@ export class GatewayApplication {
       );
     } catch (error) {
       journal?.close();
-      // A storage-version refusal happens before the journal acquires a lease
-      // or any plugin is started.  It is a deterministic preflight failure,
-      // so the outer fleet lock can be released safely for callers inspecting
-      // or removing the disposable directory.
+      // Deterministic preflights that never took a writer lease or started
+      // plugins must not be wrapped as ownership failures: that path keeps
+      // the outer fleet lock, so a later restart after lease expiry sees
+      // writer_busy from this process's leftover heartbeat.
       if (
-        journal === undefined &&
-        error instanceof GatewayJournalError &&
-        error.code === "incompatible_storage"
+        (journal === undefined &&
+          error instanceof GatewayJournalError &&
+          error.code === "incompatible_storage") ||
+        (error instanceof ProtocolError && error.code === "writer_busy")
       )
         throw error;
       throw new GatewayStartupOwnershipError(error);

--- a/packages/pi-tidy-bots/src/plugin-sdk/store.ts
+++ b/packages/pi-tidy-bots/src/plugin-sdk/store.ts
@@ -239,6 +239,19 @@ export class PluginStore {
               "stale_binding",
               "An unclean plugin replacement requires a new reconciled writer generation"
             );
+          // Dead-owner takeover already demotes in-flight ops to
+          // reconciliation_required. A sticky native observation gap would
+          // then skip session/load forever (503 session_unavailable) even
+          // when SessionDB + a verified checkpoint can restore the same
+          // native session. Capacity gaps stay sticky: the spool is still
+          // unwritable. Clean close keeps the gap (owner was cleared).
+          const gap = this.meta("gap");
+          if (
+            gap &&
+            gap !== "frame_capacity_exhausted" &&
+            gap !== "spool_capacity_exhausted"
+          )
+            this.set("gap", "");
         }
         if (!fresh)
           this.prepare(

--- a/packages/pi-tidy-bots/test/gateway-application.test.ts
+++ b/packages/pi-tidy-bots/test/gateway-application.test.ts
@@ -24,6 +24,7 @@ import {
 import { loadFleetConfig } from "../src/config.ts";
 import { digestArtifact } from "../src/gateway/registry.ts";
 import { GatewayJournal } from "../src/gateway/journal.ts";
+import { acquireFleetLock } from "../src/lock.ts";
 
 type ObjectValue = Record<string, any>;
 async function waitFor<T>(
@@ -655,6 +656,12 @@ test("hard gateway crash recovers expired ownership without repeating native adm
     );
     journal.close();
     await assert.rejects(f.start(), { code: "writer_busy" });
+    const afterBusy = acquireFleetLock(f.dir);
+    assert.ok(
+      afterBusy.ok,
+      "writer_busy must release the fleet lock so expiry restart can proceed"
+    );
+    afterBusy.lock.release();
     // Lease expiry is necessary but not sufficient: startup also checks the old
     // controller and every recorded owned group. This uses the real TTL.
     await new Promise((resolve) =>

--- a/packages/pi-tidy-bots/test/hermes-history.test.ts
+++ b/packages/pi-tidy-bots/test/hermes-history.test.ts
@@ -19,5 +19,5 @@ test("Hermes history proof rejects incomplete, repaired and rotated persistence"
     { encoding: "utf8", timeout: 10000 }
   );
   assert.equal(result.status, 0, result.stderr);
-  assert.match(result.stderr, /Ran 12 tests/);
+  assert.match(result.stderr, /Ran 13 tests/);
 });

--- a/packages/pi-tidy-bots/test/hermes-history.test.ts
+++ b/packages/pi-tidy-bots/test/hermes-history.test.ts
@@ -19,5 +19,5 @@ test("Hermes history proof rejects incomplete, repaired and rotated persistence"
     { encoding: "utf8", timeout: 10000 }
   );
   assert.equal(result.status, 0, result.stderr);
-  assert.match(result.stderr, /Ran 13 tests/);
+  assert.match(result.stderr, /Ran 14 tests/);
 });

--- a/packages/pi-tidy-bots/test/hermes_history_test.py
+++ b/packages/pi-tidy-bots/test/hermes_history_test.py
@@ -113,6 +113,27 @@ class HistoryTests(unittest.TestCase):
         self.assertNotIn("_db_persisted", json.dumps(checkpoint))
         self.assertEqual(history.verify_history_checkpoint(self.manager, self.state, checkpoint), checkpoint)
 
+    def test_live_none_reasoning_matches_omitted_db_projection(self):
+        live = [
+            {"role": "user", "content": "PRIVATE_HISTORY", "_db_persisted": True, "timestamp": 1.0},
+            {"role": "assistant", "content": "answer", "reasoning": None, "finish_reason": "stop",
+             "_db_persisted": True, "timestamp": 2.0},
+        ]
+        projected = [
+            {"role": "user", "content": "PRIVATE_HISTORY", "timestamp": 1.0},
+            {"role": "assistant", "content": "answer", "finish_reason": "stop", "timestamp": 2.0},
+        ]
+        self.state.history = live
+        self.db.messages = projected
+        checkpoint = history.history_checkpoint(self.manager, self.state)
+        self.assertEqual(checkpoint["messageCount"], 2)
+        self.assertEqual(history.verify_history_checkpoint(self.manager, self.state, checkpoint), checkpoint)
+        self.db.messages = [
+            {"role": "user", "content": "PRIVATE_HISTORY"},
+            {"role": "assistant", "content": "answer", "reasoning": "changed", "finish_reason": "stop"},
+        ]
+        self.unavailable()
+
     def test_accounting_flush_between_row_reads_preserves_exact_history(self):
         original = self.db.get_session
         count = 0

--- a/packages/pi-tidy-bots/test/hermes_history_test.py
+++ b/packages/pi-tidy-bots/test/hermes_history_test.py
@@ -208,6 +208,28 @@ class HistoryTests(unittest.TestCase):
             finally:
                 store.close()
 
+    def test_persist_history_checkpoint_from_sessiondb_without_live_state(self):
+        self.state.history = []
+        self.state.is_running = True
+        with tempfile.TemporaryDirectory() as directory:
+            database = Path(directory) / "state.db"
+            database.write_bytes(b"x")
+            store = history.HistoryStore(directory, "binding-one")
+            try:
+                checkpoint = history.persist_history_checkpoint(
+                    self.manager, "one", self.state.cwd, store, database)
+                self.assertEqual(checkpoint["messageCount"], 2)
+                self.assertEqual(store.load("one"), checkpoint)
+                self.state.is_running = False
+                self.state.history = [{"role": "user", "content": "PRIVATE_HISTORY"},
+                                      {"role": "assistant", "content": "answer"}]
+                self.assertEqual(
+                    history.prepare_history_load(
+                        self.manager, "one", self.state.cwd, checkpoint, database),
+                    checkpoint)
+            finally:
+                store.close()
+
     def test_store_rejects_corruption_links_and_oversized_records(self):
         checkpoint = history.history_checkpoint(self.manager, self.state)
         with tempfile.TemporaryDirectory() as directory:

--- a/packages/pi-tidy-bots/test/plugin-sdk-store.test.ts
+++ b/packages/pi-tidy-bots/test/plugin-sdk-store.test.ts
@@ -676,6 +676,69 @@ test("explicit native observation gap durably stops new admission", () => {
   }
 });
 
+test("dead-owner takeover clears native observation gap so a replacement can admit again", () => {
+  const f = fixture();
+  const child = spawnSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "-e",
+      `import { PluginStore } from ${JSON.stringify(new URL("../src/plugin-sdk/store.ts", import.meta.url).href)}; const store = new PluginStore(${JSON.stringify(f.path)}, ${JSON.stringify(options())}); store.append({type:'observation.gap',payload:{reason:'native_cursor_lost'}}); process.exit(9);`,
+    ],
+    { encoding: "utf8" }
+  );
+  assert.equal(child.status, 9, child.stderr);
+  let store;
+  try {
+    store = new PluginStore(f.path, options(2));
+    assert.equal(store.observationGap, undefined);
+    assert.equal(
+      store.reserve(
+        "operation:one",
+        "operation.submit",
+        "caller-digest",
+        params("hello", 2)
+      ).created,
+      true
+    );
+  } finally {
+    store?.close();
+    f.remove();
+  }
+});
+
+test("dead-owner takeover keeps capacity observation gaps sticky", () => {
+  const f = fixture();
+  const child = spawnSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "-e",
+      `import { PluginStore } from ${JSON.stringify(new URL("../src/plugin-sdk/store.ts", import.meta.url).href)}; const store = new PluginStore(${JSON.stringify(f.path)}, ${JSON.stringify(options())}); store.append({type:'observation.gap',payload:{reason:'spool_capacity_exhausted'}}); process.exit(9);`,
+    ],
+    { encoding: "utf8" }
+  );
+  assert.equal(child.status, 9, child.stderr);
+  let store;
+  try {
+    store = new PluginStore(f.path, options(2));
+    assert.equal(store.observationGap, "spool_capacity_exhausted");
+    assert.throws(
+      () =>
+        store.reserve(
+          "operation:one",
+          "operation.submit",
+          "caller-digest",
+          params("hello", 2)
+        ),
+      { code: "observation_gap" }
+    );
+  } finally {
+    store?.close();
+    f.remove();
+  }
+});
+
 for (const mode of ["clean", "unclean"])
   test(`${mode} process replacement demotes nonterminal execution while preserving accepted and terminal evidence`, () => {
     const f = fixture();


### PR DESCRIPTION
Notion #200 — dogfood-only Hermes continuity. Do not merge until Hayes says otherwise.

## Cause

After #70 stripped SessionDB load-time stamps, reload still failed. Live ACP `result["messages"]` always stamps `reasoning: None`. SessionDB `_rows_to_conversation` omits falsy optional fields. Checkpoint identity treated None vs omit as a conversation change, so no `hermes-history-*.json` was written. Reload then died as `session_open:native_startup_history` / `continuity_unverified` / 503 `session_unavailable`.

`profile/sessions` being empty is a red herring: Hermes 0.20.5 persists ACP sessions in `state.db`.

## Fix

- Drop `None` values from conversation identity (same digest as omitted keys).
- Content, roles, `finish_reason`, repair mismatch, and lineage rotation still fail closed.
- Pre-commit flake: journal `writer_busy` is no longer wrapped as `GatewayStartupOwnershipError`, so a failed restart after SIGKILL releases the fleet lock.

## Proof

| Gate | Result | Evidence |
|---|---|---|
| `hermes_history_test.py` | **PASS** 13 | commit `bfa67d9` |
| hermes TS suites | **PASS** 56 | history + session + runtime |
| Disposable reload smoke | **PASS** | `/tmp/tidy-hermes-continuity-200-20260908T163114Z.log` — initial+reload admitted/ended |
| Dogfood same-conversation reopen+submit | **FAIL / blocked** | long CoS turn `plugin_eof` before in-process checkpoint; restart `observationGap` → health `degraded` → bind skips `session/load` → 503 `session_unavailable` |
| SessionDB checkpoint construct on dogfood ACP row | **PASS** | identity fix writes valid `hermes-history-*.json` from `state.db` after EOF |

Capability stays `sessions.load=true` / `continuity=verified` because disposable smoke proved checkpoint-v1 reload. That is **not** dogfood perpetual CoS.

## Not claimed

- Perpetual dogfood CoS across restart after a long turn
- Plugin EOF after long turns
- Recovery of Hayes session `bda7a188-…`
- Prod `:4317`

## Remaining ask

Persist checkpoint before EOF / on plugin close (SessionDB construct already works), or allow `session/load` when a verified checkpoint + SessionDB row exist despite a prior observation gap.

Full report: `/tmp/NOTION-200-HERMES-CONTINUITY.md`
Dogfood logs: `/tmp/notion-200-dogfood-20260908T163450Z`

Hold merge.