### PR TITLE
fix(pi-tidy-bots): Codex turn correlation and allowlisted terminals (Astra P1-1)

### DIFF
--- a/packages/pi-tidy-bots/backends/codex/session.ts
+++ b/packages/pi-tidy-bots/backends/codex/session.ts
@@ -11,17 +11,47 @@ import {
   type JsonObject,
 } from "@mobrienv/pi-tidy-bots/plugin-protocol";
 
+type Execution = "ended" | "failed" | "cancelled" | "interrupted";
+
 interface Turn {
   operationId: string;
   turnId: string;
   nativeTurnId?: string;
+  nativeItemId?: string;
   started: boolean;
   cancelRequested?: boolean;
   onAccepted?: () => void;
-  settle?: (execution: "ended" | "failed" | "cancelled" | "interrupted") => void;
+  settle?: (execution: Execution) => void;
   order: number;
   text: string;
   message?: { id: string; text: string; revision: number };
+}
+
+const LIVE_STATUS = new Set(["inProgress", "in_progress"]);
+
+function nativeTurnIdOf(params: JsonObject): string | undefined {
+  if (nonempty(params.turnId)) return params.turnId;
+  if (object(params.turn) && nonempty(params.turn.id))
+    return String(params.turn.id);
+  return undefined;
+}
+
+function nativeItemIdOf(params: JsonObject): string | undefined {
+  if (nonempty(params.itemId)) return params.itemId;
+  if (object(params.item) && nonempty(params.item.id))
+    return String(params.item.id);
+  return undefined;
+}
+
+function terminalExecution(
+  status: unknown,
+  cancelRequested: boolean
+): Execution | undefined {
+  if (status === "completed") return "ended";
+  if (status === "failed") return "failed";
+  if (status === "interrupted")
+    return cancelRequested ? "cancelled" : "interrupted";
+  return undefined;
 }
 
 export interface CodexSessionOptions extends Pick<
@@ -163,11 +193,9 @@ export class CodexSession {
       onAccepted,
     };
     this.active = turn;
-    const finished = new Promise<"ended" | "failed" | "cancelled" | "interrupted">(
-      (resolve) => {
-        turn.settle = resolve;
-      }
-    );
+    const finished = new Promise<Execution>((resolve) => {
+      turn.settle = resolve;
+    });
     try {
       const started = await this.transport.request(
         "turn/start",
@@ -181,16 +209,26 @@ export class CodexSession {
         throw new Error();
       turn.nativeTurnId = String(started.turn.id);
       this.started(turn);
-      if (started.turn.status === "completed") this.complete(turn, "ended");
-      else if (started.turn.status === "failed") this.complete(turn, "failed");
-      else if (started.turn.status === "interrupted")
-        this.complete(turn, "interrupted");
+      const rpcStatus = started.turn.status;
+      if (rpcStatus !== undefined && !LIVE_STATUS.has(String(rpcStatus))) {
+        const execution = terminalExecution(rpcStatus, !!turn.cancelRequested);
+        if (!execution)
+          throw new ProtocolError(
+            "native_observation_gap",
+            "Codex turn status is not an allowlisted terminal"
+          );
+        this.complete(turn, execution);
+      }
       const timeout = setTimeout(
         () => this.fail(new ProtocolError("native_timeout", "Codex turn timed out")),
         this.options.promptTimeoutMs ?? 3600000
       );
       try {
         const execution = await finished;
+        if (this.lost) {
+          this.active = undefined;
+          return { disposition: turn.started ? "accepted" : "unknown" };
+        }
         this.finishMessage(turn);
         this.emit(turn, "turn.terminal", {
           execution,
@@ -261,11 +299,21 @@ export class CodexSession {
   private observe(method: string, params: JsonObject): void {
     const turn = this.active;
     if (!turn || !this.threadId || params.threadId !== this.threadId) return;
+    const notificationTurnId = nativeTurnIdOf(params);
     if (method === "turn/started" && object(params.turn)) {
-      if (!turn.nativeTurnId && nonempty(params.turn.id))
-        turn.nativeTurnId = String(params.turn.id);
+      if (!nonempty(params.turn.id)) return;
+      const id = String(params.turn.id);
+      if (turn.nativeTurnId && turn.nativeTurnId !== id) return;
+      turn.nativeTurnId = id;
       this.started(turn);
       return;
+    }
+    if (!turn.nativeTurnId || notificationTurnId !== turn.nativeTurnId) return;
+    if (method.startsWith("item/")) {
+      const itemId = nativeItemIdOf(params);
+      if (!itemId) return;
+      if (turn.nativeItemId && turn.nativeItemId !== itemId) return;
+      turn.nativeItemId = itemId;
     }
     if (
       method === "item/agentMessage/delta" &&
@@ -288,23 +336,19 @@ export class CodexSession {
       return;
     }
     if (method === "turn/completed" && object(params.turn)) {
-      const status = params.turn.status;
-      this.complete(
-        turn,
-        status === "failed"
-          ? "failed"
-          : status === "interrupted" || turn.cancelRequested
-            ? turn.cancelRequested && status !== "failed"
-              ? "cancelled"
-              : "interrupted"
-            : "ended"
+      const execution = terminalExecution(
+        params.turn.status,
+        !!turn.cancelRequested
       );
+      if (!execution)
+        throw new ProtocolError(
+          "native_observation_gap",
+          "Codex turn status is not an allowlisted terminal"
+        );
+      this.complete(turn, execution);
     }
   }
-  private complete(
-    turn: Turn,
-    execution: "ended" | "failed" | "cancelled" | "interrupted"
-  ): void {
+  private complete(turn: Turn, execution: Execution): void {
     turn.settle?.(execution);
     turn.settle = undefined;
   }
@@ -381,6 +425,9 @@ export class CodexSession {
   private fail(error: ProtocolError): void {
     if (this.lost) return;
     this.lost = true;
+    const turn = this.active;
+    turn?.settle?.("failed");
+    if (turn) turn.settle = undefined;
     this.options.onFailure(error);
   }
 }

--- a/packages/pi-tidy-bots/test/codex-adapter.test.ts
+++ b/packages/pi-tidy-bots/test/codex-adapter.test.ts
@@ -238,6 +238,109 @@ test("Codex open/submit/stream/close uses app-server not Chat Completions", asyn
   }
 });
 
+test("stale Codex turn completion does not invent a terminal for the live turn", async () => {
+  const f = await setup();
+  try {
+    await f.host.request("session.open", f.open);
+    assert.equal(
+      (
+        (await f.host.request(
+          "operation.submit",
+          f.submit("[stale-turn]")
+        )) as { disposition: string }
+      ).disposition,
+      "accepted"
+    );
+    await until(() =>
+      f.events.some((event) => event.type === "turn.terminal")
+    );
+    const terminals = f.events.filter((event) => event.type === "turn.terminal");
+    assert.equal(terminals.length, 1);
+    assert.equal(terminals[0]!.operationId, "op1");
+    assert.equal(terminals[0]!.turnId, "turn1");
+    assert.equal(terminals[0]!.payload.execution, "ended");
+    assert.equal(terminals[0]!.payload.observation, "complete");
+    const snapshots = f.events.filter((event) => event.type === "text.snapshot");
+    assert.equal(
+      snapshots[snapshots.length - 1]!.payload.text,
+      "codex:[stale-turn]"
+    );
+    assert.equal(
+      snapshots.some((event) =>
+        String(event.payload.text).includes("stale-turn-invented")
+      ),
+      false
+    );
+  } finally {
+    await f.cleanup();
+  }
+});
+
+for (const token of ["[unknown-status]", "[missing-status]"]) {
+  test(`Codex ${token} is explicit uncertainty and never success`, async () => {
+    const f = await setup();
+    try {
+      await f.host.request("session.open", f.open);
+      const submitted = (await f.host.request(
+        "operation.submit",
+        f.submit(token)
+      )) as { disposition: string };
+      assert.equal(submitted.disposition, "accepted");
+      await until(() =>
+        f.events.some((event) => event.type === "observation.gap")
+      );
+      assert.equal(
+        f.events.some(
+          (event) =>
+            event.type === "turn.terminal" &&
+            event.payload.observation === "complete"
+        ),
+        false
+      );
+      const gap = f.events.find((event) => event.type === "observation.gap");
+      assert.equal(gap?.operationId, "op1");
+      assert.equal(gap?.turnId, "turn1");
+      assert.deepEqual(gap?.payload, { code: "native_observation_gap" });
+    } finally {
+      await f.cleanup();
+    }
+  });
+}
+
+test("Codex cancel losing the race to native completed keeps the receipt completed", async () => {
+  const f = await setup();
+  try {
+    await f.host.request("session.open", f.open);
+    const submitting = f.host.request(
+      "operation.submit",
+      f.submit("[cancel-then-completed]")
+    );
+    await until(() =>
+      f.events.some((event) => event.type === "turn.started")
+    );
+    const result = await f.host.request("operation.cancel", {
+      operationId: "cancel1",
+      targetOperationId: "op1",
+      payloadDigest: "cancel-intent",
+    });
+    assert.deepEqual(result, { status: "requested" });
+    await submitting;
+    await until(() => f.events.some((event) => event.type === "turn.terminal"));
+    assert.equal(
+      f.events.find((event) => event.type === "turn.terminal")!.payload
+        .execution,
+      "ended"
+    );
+    assert.equal(
+      f.events.find((event) => event.type === "turn.terminal")!.payload
+        .observation,
+      "complete"
+    );
+  } finally {
+    await f.cleanup();
+  }
+});
+
 test("Codex cancel is cooperative turn/interrupt and not terminal proof", async () => {
   const f = await setup();
   try {

--- a/packages/pi-tidy-bots/test/codex-session.test.ts
+++ b/packages/pi-tidy-bots/test/codex-session.test.ts
@@ -135,7 +135,7 @@ test("native interrupted after cancel still reports cancelled", async (t) => {
 function fixture(t: TestContext) {
   const input = new PassThrough(),
     output = new PassThrough();
-  const events: JsonObject[] = [],
+  const events: any[] = [],
     failures: string[] = [];
   let threadId = "";
   let nativeTurnId = "";

--- a/packages/pi-tidy-bots/test/codex-session.test.ts
+++ b/packages/pi-tidy-bots/test/codex-session.test.ts
@@ -1,0 +1,220 @@
+import assert from "node:assert/strict";
+import test, { type TestContext } from "node:test";
+import { PassThrough } from "node:stream";
+import { CodexSession } from "../backends/codex/session.ts";
+import { object } from "../src/gateway/protocol.ts";
+import type { JsonObject } from "../src/gateway/protocol.ts";
+
+async function until(probe: () => boolean) {
+  const deadline = Date.now() + 2000;
+  while (!probe()) {
+    assert.ok(Date.now() < deadline, "codex session fixture timed out");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+test("stale turn completion does not settle the current operation", async (t) => {
+  const f = fixture(t);
+  await f.session.open("/tmp");
+  const completion = f.session.submit("op-current", "turn-current", [
+    { type: "text", text: "live" },
+  ]);
+  await until(() => f.events.some((event) => event.type === "turn.started"));
+  const liveTurnId = f.nativeTurnId;
+  f.notify("item/completed", {
+    threadId: f.threadId,
+    turnId: "turn-stale",
+    item: { id: "item-stale", type: "agentMessage", text: "stale-invented" },
+  });
+  f.notify("turn/completed", {
+    threadId: f.threadId,
+    turn: { id: "turn-stale", items: [], status: "completed" },
+  });
+  await Promise.resolve();
+  assert.equal(
+    f.events.some((event) => event.type === "turn.terminal"),
+    false
+  );
+  assert.equal(
+    f.events.some((event) => String(event.payload?.text ?? "").includes("stale")),
+    false
+  );
+  f.notify("item/completed", {
+    threadId: f.threadId,
+    turnId: liveTurnId,
+    item: { id: "item-live", type: "agentMessage", text: "live-final" },
+  });
+  f.notify("turn/completed", {
+    threadId: f.threadId,
+    turn: { id: liveTurnId, items: [], status: "completed" },
+  });
+  assert.deepEqual(await completion, { disposition: "accepted" });
+  const terminal = f.events.find((event) => event.type === "turn.terminal");
+  assert.equal(terminal?.operationId, "op-current");
+  assert.equal(terminal?.turnId, "turn-current");
+  assert.deepEqual(terminal?.payload, {
+    execution: "ended",
+    observation: "complete",
+    evidence: "codex_app_server_turn",
+  });
+  assert.equal(
+    f.events.find((event) => event.type === "text.snapshot")?.payload.text,
+    "live-final"
+  );
+  assert.deepEqual(f.failures, []);
+});
+
+for (const status of [undefined, "invented", "inProgress"]) {
+  test(`missing or unknown Codex terminal status ${String(status)} is uncertainty`, async (t) => {
+    const f = fixture(t);
+    await f.session.open("/tmp");
+    const completion = f.session.submit("op1", "turn1", [
+      { type: "text", text: "unknown-status" },
+    ]);
+    await until(() => f.events.some((event) => event.type === "turn.started"));
+    f.notify("turn/completed", {
+      threadId: f.threadId,
+      turn:
+        status === undefined
+          ? { id: f.nativeTurnId, items: [] }
+          : { id: f.nativeTurnId, items: [], status },
+    });
+    assert.deepEqual(await completion, { disposition: "accepted" });
+    assert.equal(
+      f.events.some((event) => event.type === "turn.terminal"),
+      false
+    );
+    assert.deepEqual(f.failures, ["native_observation_gap"]);
+    assert.deepEqual(await f.session.submit("op2", "turn2", [
+      { type: "text", text: "next" },
+    ]), { disposition: "unknown" });
+  });
+}
+
+test("cancel losing the race to native completed keeps the receipt completed", async (t) => {
+  const f = fixture(t);
+  await f.session.open("/tmp");
+  const completion = f.session.submit("op1", "turn1", [
+    { type: "text", text: "cancel-then-completed" },
+  ]);
+  await until(() => f.events.some((event) => event.type === "turn.started"));
+  assert.deepEqual(f.session.cancel("op1"), { status: "requested" });
+  await f.interrupted;
+  f.notify("turn/completed", {
+    threadId: f.threadId,
+    turn: { id: f.nativeTurnId, items: [], status: "completed" },
+  });
+  assert.deepEqual(await completion, { disposition: "accepted" });
+  assert.equal(
+    f.events.find((event) => event.type === "turn.terminal")?.payload.execution,
+    "ended"
+  );
+  assert.deepEqual(f.failures, []);
+});
+
+test("native interrupted after cancel still reports cancelled", async (t) => {
+  const f = fixture(t);
+  await f.session.open("/tmp");
+  const completion = f.session.submit("op1", "turn1", [
+    { type: "text", text: "cancel-hold" },
+  ]);
+  await until(() => f.events.some((event) => event.type === "turn.started"));
+  assert.deepEqual(f.session.cancel("op1"), { status: "requested" });
+  await f.interrupted;
+  f.notify("turn/completed", {
+    threadId: f.threadId,
+    turn: { id: f.nativeTurnId, items: [], status: "interrupted" },
+  });
+  assert.deepEqual(await completion, { disposition: "accepted" });
+  assert.equal(
+    f.events.find((event) => event.type === "turn.terminal")?.payload.execution,
+    "cancelled"
+  );
+});
+
+function fixture(t: TestContext) {
+  const input = new PassThrough(),
+    output = new PassThrough();
+  const events: JsonObject[] = [],
+    failures: string[] = [];
+  let threadId = "";
+  let nativeTurnId = "";
+  let resolveInterrupted!: (value: JsonObject) => void;
+  const interrupted = new Promise<JsonObject>((resolve) => {
+    resolveInterrupted = resolve;
+  });
+  const send = (value: JsonObject) =>
+    output.write(Buffer.from(JSON.stringify(value) + "\n"));
+  let turns = 0;
+  input.on("data", (frame) => {
+    const request = JSON.parse(frame.toString()) as JsonObject;
+    if (request.method === "initialize") {
+      send({
+        id: request.id,
+        result: {
+          userAgent: "codex-fixture/0.145.0",
+          codexHome: "/tmp",
+        },
+      });
+      return;
+    }
+    if (request.method === "thread/start") {
+      threadId = "thr-session-1";
+      send({
+        id: request.id,
+        result: { thread: { id: threadId, ephemeral: false } },
+      });
+      return;
+    }
+    if (request.method === "turn/start") {
+      nativeTurnId = `turn-${++turns}`;
+      send({
+        id: request.id,
+        result: { turn: { id: nativeTurnId, items: [], status: "inProgress" } },
+      });
+      return;
+    }
+    if (request.method === "turn/interrupt") {
+      send({
+        id: request.id,
+        result: {
+          turn: {
+            id: object(request.params) ? request.params.turnId : undefined,
+            items: [],
+            status: "interrupted",
+          },
+        },
+      });
+      resolveInterrupted(request);
+    }
+  });
+  const session = new CodexSession({
+    input,
+    output,
+    expectedHome: "/tmp",
+    requestTimeoutMs: 1000,
+    promptTimeoutMs: 1000,
+    emit: (event) => events.push(event),
+    onFailure: (error) => failures.push(error.code),
+  });
+  t.after(() => {
+    session.close();
+    input.destroy();
+    output.destroy();
+  });
+  return {
+    session,
+    events,
+    failures,
+    interrupted,
+    get threadId() {
+      return threadId;
+    },
+    get nativeTurnId() {
+      return nativeTurnId;
+    },
+    notify(method: string, params: JsonObject) {
+      send({ method, params });
+    },
+  };
+}

--- a/packages/pi-tidy-bots/test/fixtures/codex-native/app-server.mjs
+++ b/packages/pi-tidy-bots/test/fixtures/codex-native/app-server.mjs
@@ -37,19 +37,26 @@ const thread = (id, cwd) => ({
   turns: [],
 });
 
-const completeTurn = (id, request, text, status = "completed") => {
-  const nativeTurnId = `turn-${++counter}`;
+const completeTurn = (
+  id,
+  request,
+  text,
+  status = "completed",
+  existingTurnId
+) => {
+  const nativeTurnId = existingTurnId ?? `turn-${++counter}`;
   const item = {
     id: `item-${counter}`,
     type: "agentMessage",
     text,
   };
-  send({
-    id,
-    result: {
-      turn: { id: nativeTurnId, items: [], status: "inProgress" },
-    },
-  });
+  if (!existingTurnId)
+    send({
+      id,
+      result: {
+        turn: { id: nativeTurnId, items: [], status: "inProgress" },
+      },
+    });
   send({
     method: "turn/started",
     params: {
@@ -87,7 +94,10 @@ const completeTurn = (id, request, text, status = "completed") => {
     method: "turn/completed",
     params: {
       threadId: request.threadId,
-      turn: { id: nativeTurnId, items: [item], status },
+      turn:
+        status === ""
+          ? { id: nativeTurnId, items: [item] }
+          : { id: nativeTurnId, items: [item], status },
     },
   });
 };
@@ -162,7 +172,7 @@ rl.on("line", (line) => {
     const text = Array.isArray(params.input)
       ? params.input.map((part) => part.text ?? "").join("")
       : "";
-    if (text.includes("[cancel-hold]")) {
+    if (text.includes("[cancel-hold]") || text.includes("[cancel-then-completed]")) {
       const nativeTurnId = `turn-${++counter}`;
       pending.set(nativeTurnId, { id, threadId: params.threadId, text });
       send({
@@ -180,6 +190,53 @@ rl.on("line", (line) => {
       });
       return;
     }
+    if (text.includes("[stale-turn]")) {
+      const nativeTurnId = `turn-${++counter}`;
+      const staleTurnId = `turn-stale-${counter}`;
+      const staleItem = {
+        id: `item-stale-${counter}`,
+        type: "agentMessage",
+        text: "stale-turn-invented",
+      };
+      send({
+        id,
+        result: {
+          turn: { id: nativeTurnId, items: [], status: "inProgress" },
+        },
+      });
+      send({
+        method: "turn/started",
+        params: {
+          threadId: params.threadId,
+          turn: { id: staleTurnId, items: [], status: "inProgress" },
+        },
+      });
+      send({
+        method: "item/completed",
+        params: {
+          threadId: params.threadId,
+          turnId: staleTurnId,
+          item: staleItem,
+        },
+      });
+      send({
+        method: "turn/completed",
+        params: {
+          threadId: params.threadId,
+          turn: { id: staleTurnId, items: [staleItem], status: "completed" },
+        },
+      });
+      completeTurn(id, params, `codex:${text}`, "completed", nativeTurnId);
+      return;
+    }
+    if (text.includes("[unknown-status]")) {
+      completeTurn(id, params, `codex:${text}`, "invented");
+      return;
+    }
+    if (text.includes("[missing-status]")) {
+      completeTurn(id, params, `codex:${text}`, "");
+      return;
+    }
     completeTurn(id, params, `codex:${text}`);
     return;
   }
@@ -190,12 +247,15 @@ rl.on("line", (line) => {
       return;
     }
     pending.delete(params.turnId);
-    send({ id, result: { turn: { id: params.turnId, items: [], status: "interrupted" } } });
+    const status = held.text.includes("[cancel-then-completed]")
+      ? "completed"
+      : "interrupted";
+    send({ id, result: { turn: { id: params.turnId, items: [], status } } });
     send({
       method: "turn/completed",
       params: {
         threadId: held.threadId,
-        turn: { id: params.turnId, items: [], status: "interrupted" },
+        turn: { id: params.turnId, items: [], status },
       },
     });
     return;


### PR DESCRIPTION
## Summary

Astra P1-1 (wrong-turn / invented terminal) for `tidy.codex`.

`CodexSession.observe()` correlated `threadId` but applied `turn/completed` and item notifications to the current canonical operation even when the native turn/item identities did not match. Missing or unknown native status was treated as `ended`. A requested cancel overwrote a native `completed` receipt.

### Fix (`backends/codex/session.ts`)

- Correlate **thread + turn + item** identities. Stale turn/item notifications are ignored and cannot settle or snapshot the live operation.
- Allowlist native terminal statuses (`completed` / `failed` / `interrupted`). Missing or unknown status is `native_observation_gap` — never `observation: complete`.
- Native `completed` wins a cancel race. Interrupt-after-cancel still reports `cancelled`.
- Uncertainty barriers unchanged: no silent `thread/start` on load, `reserveNext` untouched.

Transport (`transport.ts`) is unchanged. This is session projection only.

### Proof

SHA: `adf2142fa02ba3226db2b9b5477e835a117fc07b`

Regression fixtures:
- stale turn completion (`[stale-turn]` + session unit test)
- missing/unknown status (`[missing-status]`, `[unknown-status]`, `inProgress` as a fake terminal)
- cancel-then-completed race (`[cancel-then-completed]`)

Commands (Node v26.7.0 / SQLite 3.53.4 via `/opt/homebrew/bin/node`):

```
cd packages/pi-tidy-bots
node --import tsx --test --test-concurrency=2 test/codex-session.test.ts test/codex-adapter.test.ts
# 18 tests, 18 pass, 0 fail

npm run check
# exit 0

npm test --workspace=@mobrienv/pi-tidy-bots
# 684 tests, 677 pass, 0 fail, 7 skipped
```

### Out of scope (next PRs)

P1-2 multi-item message collapse; P1-3 continuity proof levels; P1-4 `profile_dir` wire/drop.

### Hold

**HOLD MERGE for Hayes/Mikey.** Block Codex parity claims until the P1 backlog lands.

Prod `:4317` was not contacted. Dogfood `:4320` not required for this fixture-only slice.

Base: `main` @ `2610910` (#75).