### PR TITLE
fix(pi-tidy-bots): Codex per-item message identity (Astra P1-2)

### DIFF
--- a/packages/pi-tidy-bots/backends/codex/session.ts
+++ b/packages/pi-tidy-bots/backends/codex/session.ts
@@ -13,18 +13,24 @@ import {
 
 type Execution = "ended" | "failed" | "cancelled" | "interrupted";
 
+interface ItemMessage {
+  nativeItemId: string;
+  id: string;
+  text: string;
+  revision: number;
+  finished: boolean;
+}
+
 interface Turn {
   operationId: string;
   turnId: string;
   nativeTurnId?: string;
-  nativeItemId?: string;
   started: boolean;
   cancelRequested?: boolean;
   onAccepted?: () => void;
   settle?: (execution: Execution) => void;
   order: number;
-  text: string;
-  message?: { id: string; text: string; revision: number };
+  items: Map<string, ItemMessage>;
 }
 
 const LIVE_STATUS = new Set(["inProgress", "in_progress"]);
@@ -189,7 +195,7 @@ export class CodexSession {
       turnId,
       started: false,
       order: 0,
-      text: "",
+      items: new Map(),
       onAccepted,
     };
     this.active = turn;
@@ -229,7 +235,7 @@ export class CodexSession {
           this.active = undefined;
           return { disposition: turn.started ? "accepted" : "unknown" };
         }
-        this.finishMessage(turn);
+        this.finishOpenItems(turn);
         this.emit(turn, "turn.terminal", {
           execution,
           observation: "complete",
@@ -309,19 +315,32 @@ export class CodexSession {
       return;
     }
     if (!turn.nativeTurnId || notificationTurnId !== turn.nativeTurnId) return;
-    if (method.startsWith("item/")) {
-      const itemId = nativeItemIdOf(params);
-      if (!itemId) return;
-      if (turn.nativeItemId && turn.nativeItemId !== itemId) return;
-      turn.nativeItemId = itemId;
+    if (!method.startsWith("item/")) {
+      if (method === "turn/completed" && object(params.turn)) {
+        const execution = terminalExecution(
+          params.turn.status,
+          !!turn.cancelRequested
+        );
+        if (!execution)
+          throw new ProtocolError(
+            "native_observation_gap",
+            "Codex turn status is not an allowlisted terminal"
+          );
+        this.complete(turn, execution);
+      }
+      return;
     }
+    const itemId = nativeItemIdOf(params);
+    if (!itemId) return;
     if (
       method === "item/agentMessage/delta" &&
       typeof params.delta === "string" &&
       params.delta
     ) {
+      const item = this.itemOf(turn, itemId);
+      if (item.finished) return;
       this.started(turn);
-      this.snapshot(turn, turn.text + params.delta);
+      this.snapshot(item, turn, item.text + params.delta);
       return;
     }
     if (
@@ -329,23 +348,15 @@ export class CodexSession {
       object(params.item)
     ) {
       const text = agentText(params.item);
+      const item = text
+        ? this.itemOf(turn, itemId)
+        : turn.items.get(itemId);
+      if (!item || item.finished) return;
       if (text) {
         this.started(turn);
-        this.snapshot(turn, text);
+        this.snapshot(item, turn, text);
       }
-      return;
-    }
-    if (method === "turn/completed" && object(params.turn)) {
-      const execution = terminalExecution(
-        params.turn.status,
-        !!turn.cancelRequested
-      );
-      if (!execution)
-        throw new ProtocolError(
-          "native_observation_gap",
-          "Codex turn status is not an allowlisted terminal"
-        );
-      this.complete(turn, execution);
+      if (method === "item/completed") this.finishItem(item, turn);
     }
   }
   private complete(turn: Turn, execution: Execution): void {
@@ -376,34 +387,43 @@ export class CodexSession {
     turn.started = true;
     turn.onAccepted?.();
   }
-  private snapshot(turn: Turn, text: string): void {
+  private itemOf(turn: Turn, nativeItemId: string): ItemMessage {
+    const existing = turn.items.get(nativeItemId);
+    if (existing) return existing;
+    const item: ItemMessage = {
+      nativeItemId,
+      id: `${turn.operationId}:message:${turn.order}`,
+      text: "",
+      revision: 0,
+      finished: false,
+    };
+    turn.items.set(nativeItemId, item);
+    return item;
+  }
+  private snapshot(item: ItemMessage, turn: Turn, text: string): void {
+    if (item.finished) return;
     if (Buffer.byteLength(text) > 512 * 1024) throw new Error();
-    if (!turn.message) {
+    if (!item.revision) {
       const order = turn.order++;
-      turn.message = {
-        id: `${turn.operationId}:message:${order}`,
-        text: "",
-        revision: 0,
-      };
+      item.id = `${turn.operationId}:message:${order}`;
       this.emit(
         turn,
         "message.started",
         { role: "assistant", order },
-        { messageId: turn.message.id }
+        { messageId: item.id }
       );
     }
-    turn.text = text;
-    turn.message.text = text;
+    item.text = text;
     this.emit(
       turn,
       "text.snapshot",
-      { text, revision: ++turn.message.revision },
-      { messageId: turn.message.id, blockId: "body" }
+      { text, revision: ++item.revision },
+      { messageId: item.id, blockId: "body" }
     );
   }
-  private finishMessage(turn: Turn): void {
-    if (!turn.message) return;
-    const message = turn.message;
+  private finishItem(item: ItemMessage, turn: Turn): void {
+    if (item.finished || !item.revision) return;
+    item.finished = true;
     this.emit(
       turn,
       "message.finished",
@@ -413,14 +433,16 @@ export class CodexSession {
           {
             type: "text",
             blockId: "body",
-            text: message.text,
-            revision: message.revision,
+            text: item.text,
+            revision: item.revision,
           },
         ],
       },
-      { messageId: message.id }
+      { messageId: item.id }
     );
-    turn.message = undefined;
+  }
+  private finishOpenItems(turn: Turn): void {
+    for (const item of turn.items.values()) this.finishItem(item, turn);
   }
   private fail(error: ProtocolError): void {
     if (this.lost) return;

--- a/packages/pi-tidy-bots/test/codex-adapter.test.ts
+++ b/packages/pi-tidy-bots/test/codex-adapter.test.ts
@@ -25,6 +25,13 @@ const fixtureExecutable = fileURLToPath(
   new URL("./fixtures/codex-native/app-server.mjs", import.meta.url)
 );
 
+function finishedText(event: GatewayPluginEvent): string {
+  const blocks = event.payload.blocks;
+  if (!Array.isArray(blocks)) return "";
+  const block = blocks[0] as { text?: unknown } | undefined;
+  return typeof block?.text === "string" ? block.text : "";
+}
+
 async function until(probe: () => boolean | Promise<boolean>) {
   const deadline = Date.now() + 8000;
   while (!(await probe())) {
@@ -261,8 +268,8 @@ test("two Codex assistant items stay two finished messages", async () => {
     assert.equal(finished[0]!.messageId, "op1:message:0");
     assert.equal(finished[1]!.messageId, "op1:message:1");
     assert.notEqual(finished[0]!.messageId, finished[1]!.messageId);
-    assert.equal(finished[0]!.payload.blocks?.[0]?.text, "First");
-    assert.equal(finished[1]!.payload.blocks?.[0]?.text, "Second");
+    assert.equal(finishedText(finished[0]!), "First");
+    assert.equal(finishedText(finished[1]!), "Second");
     assert.equal(
       f.events.find((event) => event.type === "turn.terminal")!.payload
         .execution,

--- a/packages/pi-tidy-bots/test/codex-adapter.test.ts
+++ b/packages/pi-tidy-bots/test/codex-adapter.test.ts
@@ -238,6 +238,46 @@ test("Codex open/submit/stream/close uses app-server not Chat Completions", asyn
   }
 });
 
+test("two Codex assistant items stay two finished messages", async () => {
+  const f = await setup();
+  try {
+    await f.host.request("session.open", f.open);
+    assert.equal(
+      (
+        (await f.host.request(
+          "operation.submit",
+          f.submit("[multi-item]")
+        )) as { disposition: string }
+      ).disposition,
+      "accepted"
+    );
+    await until(() =>
+      f.events.some((event) => event.type === "turn.terminal")
+    );
+    const finished = f.events.filter(
+      (event) => event.type === "message.finished"
+    );
+    assert.equal(finished.length, 2);
+    assert.equal(finished[0]!.messageId, "op1:message:0");
+    assert.equal(finished[1]!.messageId, "op1:message:1");
+    assert.notEqual(finished[0]!.messageId, finished[1]!.messageId);
+    assert.equal(finished[0]!.payload.blocks?.[0]?.text, "First");
+    assert.equal(finished[1]!.payload.blocks?.[0]?.text, "Second");
+    assert.equal(
+      f.events.find((event) => event.type === "turn.terminal")!.payload
+        .execution,
+      "ended"
+    );
+    assert.equal(
+      f.events.find((event) => event.type === "turn.terminal")!.payload
+        .observation,
+      "complete"
+    );
+  } finally {
+    await f.cleanup();
+  }
+});
+
 test("stale Codex turn completion does not invent a terminal for the live turn", async () => {
   const f = await setup();
   try {

--- a/packages/pi-tidy-bots/test/codex-session.test.ts
+++ b/packages/pi-tidy-bots/test/codex-session.test.ts
@@ -112,6 +112,82 @@ test("cancel losing the race to native completed keeps the receipt completed", a
   assert.deepEqual(f.failures, []);
 });
 
+test("two native assistant items become two authoritative messages", async (t) => {
+  const f = fixture(t);
+  await f.session.open("/tmp");
+  const completion = f.session.submit("op1", "turn1", [
+    { type: "text", text: "multi-item" },
+  ]);
+  await until(() => f.events.some((event) => event.type === "turn.started"));
+  f.notify("item/agentMessage/delta", {
+    threadId: f.threadId,
+    turnId: f.nativeTurnId,
+    itemId: "item-a",
+    delta: "Fir",
+  });
+  f.notify("item/completed", {
+    threadId: f.threadId,
+    turnId: f.nativeTurnId,
+    item: { id: "item-a", type: "agentMessage", text: "First" },
+  });
+  f.notify("item/agentMessage/delta", {
+    threadId: f.threadId,
+    turnId: f.nativeTurnId,
+    itemId: "item-b",
+    delta: "Sec",
+  });
+  f.notify("item/completed", {
+    threadId: f.threadId,
+    turnId: f.nativeTurnId,
+    item: { id: "item-b", type: "agentMessage", text: "Second" },
+  });
+  f.notify("item/completed", {
+    threadId: f.threadId,
+    turnId: f.nativeTurnId,
+    item: { id: "item-a", type: "agentMessage", text: "Third" },
+  });
+  f.notify("item/agentMessage/delta", {
+    threadId: f.threadId,
+    turnId: f.nativeTurnId,
+    itemId: "item-b",
+    delta: "extra",
+  });
+  f.notify("turn/completed", {
+    threadId: f.threadId,
+    turn: { id: f.nativeTurnId, items: [], status: "completed" },
+  });
+  assert.deepEqual(await completion, { disposition: "accepted" });
+  const started = f.events.filter((event) => event.type === "message.started");
+  const finished = f.events.filter((event) => event.type === "message.finished");
+  assert.deepEqual(
+    started.map((event) => [event.messageId, event.payload.order]),
+    [
+      ["op1:message:0", 0],
+      ["op1:message:1", 1],
+    ]
+  );
+  assert.equal(finished.length, 2);
+  assert.equal(finished[0]?.messageId, "op1:message:0");
+  assert.equal(finished[1]?.messageId, "op1:message:1");
+  assert.equal(finished[0]?.payload.blocks?.[0]?.text, "First");
+  assert.equal(finished[1]?.payload.blocks?.[0]?.text, "Second");
+  assert.ok(
+    f.events.findIndex((event) => event.type === "message.finished") <
+      f.events.findIndex((event) => event.type === "turn.terminal")
+  );
+  assert.equal(
+    f.events.some((event) => String(event.payload?.text ?? "").includes("Third")),
+    false
+  );
+  assert.equal(
+    f.events.some((event) =>
+      String(event.payload?.text ?? "").includes("extra")
+    ),
+    false
+  );
+  assert.deepEqual(f.failures, []);
+});
+
 test("native interrupted after cancel still reports cancelled", async (t) => {
   const f = fixture(t);
   await f.session.open("/tmp");

--- a/packages/pi-tidy-bots/test/fixtures/codex-native/app-server.mjs
+++ b/packages/pi-tidy-bots/test/fixtures/codex-native/app-server.mjs
@@ -190,6 +190,55 @@ rl.on("line", (line) => {
       });
       return;
     }
+    if (text.includes("[multi-item]")) {
+      const nativeTurnId = `turn-${++counter}`;
+      const first = { id: "item-a", type: "agentMessage", text: "First" };
+      const second = { id: "item-b", type: "agentMessage", text: "Second" };
+      send({
+        id,
+        result: {
+          turn: { id: nativeTurnId, items: [], status: "inProgress" },
+        },
+      });
+      send({
+        method: "turn/started",
+        params: {
+          threadId: params.threadId,
+          turn: { id: nativeTurnId, items: [], status: "inProgress" },
+        },
+      });
+      for (const item of [first, second]) {
+        send({
+          method: "item/started",
+          params: {
+            threadId: params.threadId,
+            turnId: nativeTurnId,
+            startedAtMs: 1,
+            item,
+          },
+        });
+        send({
+          method: "item/completed",
+          params: {
+            threadId: params.threadId,
+            turnId: nativeTurnId,
+            item,
+          },
+        });
+      }
+      send({
+        method: "turn/completed",
+        params: {
+          threadId: params.threadId,
+          turn: {
+            id: nativeTurnId,
+            items: [first, second],
+            status: "completed",
+          },
+        },
+      });
+      return;
+    }
     if (text.includes("[stale-turn]")) {
       const nativeTurnId = `turn-${++counter}`;
       const staleTurnId = `turn-stale-${counter}`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Astra P1-2 (multi native assistant items collapse to one message) for `tidy.codex`.

`CodexSession` fed every `item/started` and `item/completed` into a single `turn.message`, ignored native item identity after the first item, and called `finishMessage()` only at turn termination. Two completed `agentMessage` items (`item-a` "First", `item-b` "Second") became one `message.finished` with only the last text.

### Fix (`backends/codex/session.ts`)

- Canonical message identity per native item (`item-a` / `item-b` stay distinct).
- Deltas append on that item; `item/completed` is authoritative replace + finalize once.
- Appearance order is preserved (`op1:message:0`, `op1:message:1`).
- Late completions/deltas on a finished item are ignored.
- P1-1 turn/terminal correlation and unknown-status barriers are unchanged.

Transport (`transport.ts`) is unchanged. This is session projection only.

### Proof

SHA: `dd087fc09bf3b080f774fdacfb3508a29c98f52f`

Stacked on #76 @ `adf2142fa02ba3226db2b9b5477e835a117fc07b` (`cursor/astra-p1-wrong-turn-a8df`).

Regression fixtures:

- session: two items with deltas + authoritative completions; late "Third"/extra ignored
- adapter `[multi-item]`: two completed agentMessage items → two finished messages

Commands (Node v26.7.0 / SQLite 3.53.4 via `/opt/homebrew/bin/node`):

```
cd packages/pi-tidy-bots
node --import tsx --test --test-concurrency=2 test/codex-session.test.ts test/codex-adapter.test.ts
# 20 tests, 20 pass, 0 fail

npm run check
# exit 0

npm test --workspace=@mobrienv/pi-tidy-bots
# 686 tests, 680 pass, 0 fail, 6 skipped
# exit 0
```

### Out of scope (next PRs)

P1-3 continuity proof levels; P1-4 `profile_dir` wire/drop.

### Hold

**HOLD MERGE for Hayes/Mikey.** Merge after #76. Block Codex parity claims until the P1 backlog lands.

Prod `:4317` was not contacted.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3ab8282-9186-4e96-a896-f95db03ee343?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3ab8282-9186-4e96-a896-f95db03ee343&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

