### PR TITLE
fix(pi-tidy-bots): continuity proof levels (Astra P1-3)

### DIFF
--- a/packages/pi-tidy-bots/backends/codex/CAPABILITIES.md
+++ b/packages/pi-tidy-bots/backends/codex/CAPABILITIES.md
@@ -9,7 +9,9 @@ control plane. This adapter speaks Codex app-server JSON-RPC (`initialize`,
 | Text open/submit/stream/close | yes | Fixture conformance |
 | Cancel | cooperative `turn/interrupt` | Fixture only |
 | Session load | `sessions.load=true` | Fail-closed on miss; never `thread/start` on load |
-| Continuity | `verified` | Protocol requires this when load is advertised. Fixture reload proved same thread id. Native Codex `thread/resume` across a real app-server restart PASSed (`test/codex-native-smoke.test.ts`, log `/tmp/tidy-codex-197-native-smoke.log`). |
+| Continuity | `verified` | Means the advertised **identity-only** proof succeeded. Not Pi/Hermes retained-history verification. |
+| Proof | `identity-only` | Expected isolated `CODEX_HOME` plus the exact returned thread id. No history digest, message-count, or checkpoint comparison. |
+| Empty seat | `non-restorable` | Never-prompted / unprompted threads may lack a resumable rollout. They stay fail-closed; restart-availability is not claimed. |
 | Steer | false | Native `turn/steer` exists; unmapped |
 | Questions | false | No generic question cards |
 | Compact | false | Native `thread/compact` exists; unmapped |
@@ -17,6 +19,8 @@ control plane. This adapter speaks Codex app-server JSON-RPC (`initialize`,
 | Fleet tools | false | Dual-backend Codex↔Pi fixture smoke is text-only |
 | Auth | native profile | `CODEX_HOME` / `auth.json` or named env keys. No secrets in manifest |
 
-Mikey invariant: fleet seats are perpetual. Restart must `thread/resume` the
-same native thread or fail closed. Empty never-prompted threads have no
-rollout and stay fail-closed (no silent `thread/start`).
+Mikey invariant: fleet seats are perpetual. Identity/fail-closed is the
+consistent rule for every new seat — not restart-availability. Restart must
+`thread/resume` the same native thread or fail closed. Empty never-prompted
+threads have no rollout and stay explicitly `non-restorable` (no silent
+`thread/start`).

--- a/packages/pi-tidy-bots/backends/codex/adapter.ts
+++ b/packages/pi-tidy-bots/backends/codex/adapter.ts
@@ -18,11 +18,18 @@ import {
   type CodexRuntime,
 } from "./runtime.ts";
 
-// Protocol requires load ⇒ verified. Fixture reload proved same-thread
-// resume and fail-closed miss. Native Codex reload smoke is still not-run.
+// Load is fail-closed identity proof only: isolated home + exact thread id.
+// That is not Pi/Hermes retained-history verification. Never-prompted seats
+// stay non-restorable (Codex unprompted threads may lack a resumable rollout).
 export const CODEX_CAPABILITIES: CapabilityDescriptor = {
   input: { text: true, mediaTypes: [], maxMediaBytes: 0 },
-  sessions: { load: true, import: false, continuity: "verified" },
+  sessions: {
+    load: true,
+    import: false,
+    continuity: "verified",
+    proof: "identity-only",
+    emptySeat: "non-restorable",
+  },
   output: { text: "snapshots", tools: false, usage: "unknown" },
   operations: {
     nativeDedupe: "none",
@@ -158,6 +165,16 @@ export function startCodexAdapter(): PluginRuntime {
           status: "opened",
           nativeReference: `codex:${native.nativeReference}`,
           continuity: params.mode === "load" ? "verified" : "unverified",
+          proof: params.mode === "load" ? "identity-only" : "none",
+          ...(params.mode === "load"
+            ? {
+                evidence: {
+                  provenance: "codex-thread-identity",
+                  expectedHome: true,
+                  threadId: native.nativeReference,
+                },
+              }
+            : {}),
         };
       },
       async "operation.submit"(params, ctx) {

--- a/packages/pi-tidy-bots/backends/codex/session.ts
+++ b/packages/pi-tidy-bots/backends/codex/session.ts
@@ -155,6 +155,8 @@ export class CodexSession {
           "continuity_unverified",
           "Codex load did not restore the exact retained thread"
         );
+      // Identity-only: expected home + returned thread id. No history
+      // digest, message count, or checkpoint comparison is available.
       this.threadId = resumedId;
       return this.threadId;
     }

--- a/packages/pi-tidy-bots/backends/hermes/adapter.ts
+++ b/packages/pi-tidy-bots/backends/hermes/adapter.ts
@@ -27,7 +27,13 @@ export const HERMES_CAPABILITIES: CapabilityDescriptor = {
     mediaTypes: ["text/plain", "image/png", "image/jpeg"],
     maxMediaBytes: 512 * 1024,
   },
-  sessions: { load: true, import: false, continuity: "verified" },
+  sessions: {
+    load: true,
+    import: false,
+    continuity: "verified",
+    proof: "retained-history",
+    emptySeat: "non-restorable",
+  },
   output: { text: "snapshots", tools: true, usage: "unknown" },
   operations: {
     nativeDedupe: "none",
@@ -170,6 +176,15 @@ export function startHermesAdapter(): PluginRuntime {
           status: "opened",
           nativeReference: `hermes:${native.nativeReference}`,
           continuity: params.mode === "load" ? "verified" : "unverified",
+          proof: params.mode === "load" ? "retained-history" : "none",
+          ...(params.mode === "load"
+            ? {
+                evidence: {
+                  provenance: "hermes-checkpoint-v1",
+                  sessionId: native.nativeReference,
+                },
+              }
+            : {}),
         };
       },
       async "operation.submit"(params, ctx) {

--- a/packages/pi-tidy-bots/backends/pi/adapter.ts
+++ b/packages/pi-tidy-bots/backends/pi/adapter.ts
@@ -31,13 +31,21 @@ import {
 } from "@mobrienv/pi-tidy-bots/src/rpc.ts";
 
 // Expand this profile only after its native feature conformance cells pass.
+// Load proof is retained-history (binding + file + settings + messageCount).
+// Empty never-prompted seats stay non-restorable: checkpoint requires ≥1 message.
 export const PI_CAPABILITIES: CapabilityDescriptor = {
   input: {
     text: true,
     mediaTypes: ["text/plain", "image/png", "image/jpeg"],
     maxMediaBytes: 512 * 1024,
   },
-  sessions: { load: true, import: false, continuity: "verified" },
+  sessions: {
+    load: true,
+    import: false,
+    continuity: "verified",
+    proof: "retained-history",
+    emptySeat: "non-restorable",
+  },
   output: { text: "snapshots", tools: true, usage: "unknown" },
   operations: {
     nativeDedupe: "none",
@@ -778,6 +786,17 @@ export function startPiAdapter(): PluginRuntime {
           status: "opened",
           nativeReference,
           continuity: checkpoint ? "verified" : "unverified",
+          proof: checkpoint ? "retained-history" : "none",
+          ...(checkpoint
+            ? {
+                evidence: {
+                  provenance: "pi-history-checkpoint",
+                  sessionId: checkpoint.history.sessionId,
+                  sessionFile: checkpoint.history.file,
+                  messageCount: checkpoint.messageCount,
+                },
+              }
+            : {}),
         };
       },
       async "session.snapshot"(params) {

--- a/packages/pi-tidy-bots/src/gateway/application.ts
+++ b/packages/pi-tidy-bots/src/gateway/application.ts
@@ -38,6 +38,8 @@ import {
 import {
   object,
   ProtocolError,
+  sessionOpenEvidenceMatches,
+  sessionProofOf,
   type CapabilityDescriptor,
   type GatewayPluginEvent,
 } from "./protocol.ts";
@@ -124,6 +126,11 @@ function effectiveCapabilities(
         native.sessions.load && native.sessions.continuity === "verified"
           ? "verified"
           : "unverified",
+      proof:
+        native.sessions.load && native.sessions.continuity === "verified"
+          ? (native.sessions.proof ?? "none")
+          : "none",
+      emptySeat: native.sessions.emptySeat ?? "non-restorable",
     },
     output: {
       text: native.output.text,
@@ -659,7 +666,12 @@ export class GatewayApplication {
         response.status !== "opened" ||
         (existing &&
           (response.nativeReference !== nativeReference ||
-            response.continuity !== "verified"))
+            response.continuity !== "verified" ||
+            response.proof !== sessionProofOf(capabilities.sessions) ||
+            !sessionOpenEvidenceMatches(
+              response,
+              sessionProofOf(capabilities.sessions)
+            )))
       ) {
         observeOpenFailure(
           object(response) && response.status === "creation_unknown"

--- a/packages/pi-tidy-bots/src/gateway/protocol.ts
+++ b/packages/pi-tidy-bots/src/gateway/protocol.ts
@@ -153,12 +153,29 @@ export class FrameDecoder {
   }
 }
 
+export type SessionProof = "none" | "identity-only" | "retained-history";
+export type EmptySeatPolicy = "non-restorable" | "restartable";
+export type ContinuityStatus = "verified" | "unverified";
+export type SessionEvidenceProvenance =
+  | "codex-thread-identity"
+  | "pi-history-checkpoint"
+  | "hermes-checkpoint-v1";
+
+/** Load support, proof type, and evidence provenance are distinct.
+ * `load`/`import` mean restore is attempted. `proof` is what a successful
+ * load actually proved. `continuity: verified` means that advertised proof
+ * succeeded — not that every backend has Pi/Hermes-equivalent history.
+ * Never-prompted seats may stay `emptySeat: non-restorable`; fail closed
+ * rather than invent restart-availability.
+ */
 export interface CapabilityDescriptor {
   input: { text: true; mediaTypes: string[]; maxMediaBytes: number };
   sessions: {
     load: boolean;
     import: boolean;
-    continuity: "verified" | "unverified";
+    continuity: ContinuityStatus;
+    proof?: SessionProof;
+    emptySeat?: EmptySeatPolicy;
   };
   output: {
     text: "final-only" | "snapshots";
@@ -371,7 +388,7 @@ export function validateCapabilities(value: unknown): CapabilityDescriptor {
   if (!object(value)) return fail("Missing capabilities");
   const sections: Record<string, string[]> = {
     input: ["text", "mediaTypes", "maxMediaBytes"],
-    sessions: ["load", "import", "continuity"],
+    sessions: ["load", "import", "continuity", "proof", "emptySeat"],
     output: ["text", "tools", "usage"],
     operations: [
       "nativeDedupe",
@@ -446,6 +463,25 @@ export function validateCapabilities(value: unknown): CapabilityDescriptor {
   ];
   if (enums.some(([entry, allowed]) => !allowed.includes(String(entry))))
     return fail("Unknown capability value");
+  const restore = descriptor.sessions.load || descriptor.sessions.import;
+  const proof = descriptor.sessions.proof ?? "none";
+  if (!["none", "identity-only", "retained-history"].includes(proof))
+    return fail("Unknown session proof");
+  if (
+    descriptor.sessions.emptySeat !== undefined &&
+    descriptor.sessions.emptySeat !== "non-restorable" &&
+    descriptor.sessions.emptySeat !== "restartable"
+  )
+    return fail("Unknown empty-seat policy");
+  if (restore) {
+    if (descriptor.sessions.continuity !== "verified")
+      return fail("Session restoration requires verified continuity");
+    if (proof === "none")
+      return fail("Session restoration requires an explicit proof level");
+    if (descriptor.sessions.emptySeat === undefined)
+      return fail("Session restoration requires an explicit empty-seat policy");
+  } else if (proof !== "none")
+    return fail("Proof without load or import overclaims restoration");
   const positive = (entry: unknown) =>
     Number.isSafeInteger(entry) && Number(entry) > 0;
   if (
@@ -459,10 +495,36 @@ export function validateCapabilities(value: unknown): CapabilityDescriptor {
       descriptor.operations.nativeReplayGapSemantics !== "explicit-gap")
   )
     return fail("Cursor replay requires retention and explicit gap semantics");
-  if (
-    (descriptor.sessions.load || descriptor.sessions.import) &&
-    descriptor.sessions.continuity !== "verified"
-  )
-    return fail("Session restoration requires verified continuity");
   return descriptor;
+}
+
+export function sessionProofOf(
+  sessions: CapabilityDescriptor["sessions"]
+): SessionProof {
+  return sessions.proof ?? "none";
+}
+
+export function emptySeatOf(
+  sessions: CapabilityDescriptor["sessions"]
+): EmptySeatPolicy {
+  return sessions.emptySeat ?? "non-restorable";
+}
+
+export function sessionOpenEvidenceMatches(
+  result: JsonObject,
+  advertised: SessionProof
+): boolean {
+  if (advertised === "none")
+    return result.proof === "none" || result.proof === undefined;
+  if (result.continuity !== "verified" || result.proof !== advertised)
+    return false;
+  if (!object(result.evidence) || !nonempty(result.evidence.provenance))
+    return false;
+  const provenance = String(result.evidence.provenance);
+  if (advertised === "identity-only")
+    return provenance === "codex-thread-identity";
+  return (
+    provenance === "pi-history-checkpoint" ||
+    provenance === "hermes-checkpoint-v1"
+  );
 }

--- a/packages/pi-tidy-bots/src/gateway/protocol.ts
+++ b/packages/pi-tidy-bots/src/gateway/protocol.ts
@@ -157,6 +157,7 @@ export type SessionProof = "none" | "identity-only" | "retained-history";
 export type EmptySeatPolicy = "non-restorable" | "restartable";
 export type ContinuityStatus = "verified" | "unverified";
 export type SessionEvidenceProvenance =
+  | "native-identity"
   | "codex-thread-identity"
   | "pi-history-checkpoint"
   | "hermes-checkpoint-v1";
@@ -522,7 +523,10 @@ export function sessionOpenEvidenceMatches(
     return false;
   const provenance = String(result.evidence.provenance);
   if (advertised === "identity-only")
-    return provenance === "codex-thread-identity";
+    return (
+      provenance !== "pi-history-checkpoint" &&
+      provenance !== "hermes-checkpoint-v1"
+    );
   return (
     provenance === "pi-history-checkpoint" ||
     provenance === "hermes-checkpoint-v1"

--- a/packages/pi-tidy-bots/src/gateway/schema/capabilities.schema.json
+++ b/packages/pi-tidy-bots/src/gateway/schema/capabilities.schema.json
@@ -50,7 +50,16 @@
           "type": "boolean"
         },
         "continuity": {
-          "enum": ["verified", "unverified"]
+          "enum": ["verified", "unverified"],
+          "description": "Whether this adapter's advertised proof succeeded. Not a claim that every backend has retained-history verification."
+        },
+        "proof": {
+          "enum": ["none", "identity-only", "retained-history"],
+          "description": "What a successful load actually proved. identity-only is not Pi/Hermes-equivalent history verification."
+        },
+        "emptySeat": {
+          "enum": ["non-restorable", "restartable"],
+          "description": "Never-prompted seats may remain explicitly non-restorable. Fail closed rather than invent restart-availability."
         }
       },
       "required": ["load", "import", "continuity"],
@@ -94,9 +103,16 @@
             ]
           },
           "then": {
+            "required": ["proof", "emptySeat"],
             "properties": {
               "continuity": {
                 "const": "verified"
+              },
+              "proof": {
+                "enum": ["identity-only", "retained-history"]
+              },
+              "emptySeat": {
+                "enum": ["non-restorable", "restartable"]
               }
             }
           }

--- a/packages/pi-tidy-bots/test/codex-adapter.test.ts
+++ b/packages/pi-tidy-bots/test/codex-adapter.test.ts
@@ -220,10 +220,15 @@ test("Codex open/submit/stream/close uses app-server not Chat Completions", asyn
     const opened = (await f.host.request("session.open", f.open)) as {
       nativeReference: string;
       continuity: string;
+      proof: string;
     };
     assert.match(opened.nativeReference, /^codex:thr-fixture-/);
     assert.equal(opened.continuity, "unverified");
-    // New sessions stay unverified. Load continuity is proven separately.
+    assert.equal(opened.proof, "none");
+    assert.equal(f.host.capabilities.sessions.proof, "identity-only");
+    assert.equal(f.host.capabilities.sessions.emptySeat, "non-restorable");
+    assert.notEqual(f.host.capabilities.sessions.proof, "retained-history");
+    // New sessions stay unverified. Load proof is identity-only, not history.
     assert.equal(
       ((await f.host.request("operation.submit", f.submit("hello"))) as {
         disposition: string;
@@ -473,8 +478,22 @@ test("Codex load restores the same native thread across adapter restart", async 
         operationId: "opening-2",
         mode: "load",
         nativeReference: first.nativeReference,
-      })) as { nativeReference: string };
+      })) as {
+        nativeReference: string;
+        continuity: string;
+        proof: string;
+        evidence?: { provenance?: string; threadId?: string };
+      };
       assert.equal(loaded.nativeReference, first.nativeReference);
+      assert.equal(loaded.continuity, "verified");
+      assert.equal(loaded.proof, "identity-only");
+      assert.notEqual(loaded.proof, "retained-history");
+      assert.deepEqual(loaded.evidence, {
+        provenance: "codex-thread-identity",
+        expectedHome: true,
+        threadId: first.nativeReference.slice("codex:".length),
+      });
+      assert.equal(reload.capabilities.sessions.proof, "identity-only");
       assert.equal(
         (
           (await reload.request("operation.submit", {

--- a/packages/pi-tidy-bots/test/fixtures/gateway-application/backend.mjs
+++ b/packages/pi-tidy-bots/test/fixtures/gateway-application/backend.mjs
@@ -370,6 +370,12 @@ input.on("line", (line) => {
             p.config.discovery === true || p.config.sessionsLoad === true
               ? "verified"
               : "unverified",
+          ...(p.config.discovery === true || p.config.sessionsLoad === true
+            ? {
+                proof: "identity-only",
+                emptySeat: "non-restorable",
+              }
+            : {}),
         },
         output: { text: "snapshots", tools: true, usage: "unknown" },
         operations: {
@@ -424,7 +430,16 @@ input.on("line", (line) => {
     respond(message, {
       status: "opened",
       nativeReference,
-      ...(p.mode === "load" ? { continuity: "verified" } : {}),
+      ...(p.mode === "load"
+        ? {
+            continuity: "verified",
+            proof: "identity-only",
+            evidence: {
+              provenance: "native-identity",
+              nativeReference,
+            },
+          }
+        : { continuity: "unverified", proof: "none" }),
     });
   } else if (message.method === "session.compact") {
     record({ method: "session.compact", ...p });

--- a/packages/pi-tidy-bots/test/gateway-protocol.test.ts
+++ b/packages/pi-tidy-bots/test/gateway-protocol.test.ts
@@ -7,6 +7,7 @@ import {
   encodeFrame,
   FrameDecoder,
   parseRpc,
+  sessionOpenEvidenceMatches,
   validateCapabilities,
   validateEvent,
   validateLimits,
@@ -160,6 +161,75 @@ test("capabilities reject unbacked guarantees and unknown required extensions", 
     () =>
       validateCapabilities({
         ...capabilities(),
+        sessions: {
+          load: true,
+          import: false,
+          continuity: "verified",
+        },
+      }),
+    { code: "invalid_capabilities" }
+  );
+  assert.throws(
+    () =>
+      validateCapabilities({
+        ...capabilities(),
+        sessions: {
+          load: true,
+          import: false,
+          continuity: "verified",
+          proof: "none",
+          emptySeat: "non-restorable",
+        },
+      }),
+    { code: "invalid_capabilities" }
+  );
+  assert.throws(
+    () =>
+      validateCapabilities({
+        ...capabilities(),
+        sessions: {
+          ...capabilities().sessions,
+          proof: "identity-only",
+        },
+      }),
+    { code: "invalid_capabilities" }
+  );
+  assert.deepEqual(
+    validateCapabilities({
+      ...capabilities(),
+      sessions: {
+        load: true,
+        import: false,
+        continuity: "verified",
+        proof: "identity-only",
+        emptySeat: "non-restorable",
+      },
+    }).sessions,
+    {
+      load: true,
+      import: false,
+      continuity: "verified",
+      proof: "identity-only",
+      emptySeat: "non-restorable",
+    }
+  );
+  assert.equal(
+    validateCapabilities({
+      ...capabilities(),
+      sessions: {
+        load: true,
+        import: false,
+        continuity: "verified",
+        proof: "retained-history",
+        emptySeat: "non-restorable",
+      },
+    }).sessions.proof,
+    "retained-history"
+  );
+  assert.throws(
+    () =>
+      validateCapabilities({
+        ...capabilities(),
         "org.example.feature": { required: true },
       }),
     { code: "invalid_capabilities" }
@@ -170,6 +240,48 @@ test("capabilities reject unbacked guarantees and unknown required extensions", 
       "org.example.feature": { required: false },
     })["org.example.feature"],
     { required: false }
+  );
+});
+
+test("session open evidence distinguishes identity-only from retained-history", () => {
+  const identity = {
+    continuity: "verified",
+    proof: "identity-only",
+    evidence: {
+      provenance: "codex-thread-identity",
+      expectedHome: true,
+      threadId: "thr-1",
+    },
+  };
+  const history = {
+    continuity: "verified",
+    proof: "retained-history",
+    evidence: {
+      provenance: "pi-history-checkpoint",
+      messageCount: 1,
+    },
+  };
+  assert.equal(sessionOpenEvidenceMatches(identity, "identity-only"), true);
+  assert.equal(sessionOpenEvidenceMatches(identity, "retained-history"), false);
+  assert.equal(sessionOpenEvidenceMatches(history, "retained-history"), true);
+  assert.equal(sessionOpenEvidenceMatches(history, "identity-only"), false);
+  assert.equal(
+    sessionOpenEvidenceMatches(
+      { continuity: "verified", proof: "identity-only" },
+      "identity-only"
+    ),
+    false
+  );
+  assert.equal(
+    sessionOpenEvidenceMatches(
+      {
+        continuity: "verified",
+        proof: "retained-history",
+        evidence: { provenance: "codex-thread-identity" },
+      },
+      "retained-history"
+    ),
+    false
   );
 });
 
@@ -236,6 +348,26 @@ test("published schemas compile strictly and agree with required capability and 
       operations: { ...capabilities().operations, nativeDedupe: "durable" },
     }),
     false
+  );
+  assert.equal(
+    check({
+      ...capabilities(),
+      sessions: { load: true, import: false, continuity: "verified" },
+    }),
+    false
+  );
+  assert.equal(
+    check({
+      ...capabilities(),
+      sessions: {
+        load: true,
+        import: false,
+        continuity: "verified",
+        proof: "identity-only",
+        emptySeat: "non-restorable",
+      },
+    }),
+    true
   );
   const terminal = {
     bindingId: "b",

--- a/packages/pi-tidy-bots/test/gateway-protocol.test.ts
+++ b/packages/pi-tidy-bots/test/gateway-protocol.test.ts
@@ -262,6 +262,17 @@ test("session open evidence distinguishes identity-only from retained-history", 
     },
   };
   assert.equal(sessionOpenEvidenceMatches(identity, "identity-only"), true);
+  assert.equal(
+    sessionOpenEvidenceMatches(
+      {
+        continuity: "verified",
+        proof: "identity-only",
+        evidence: { provenance: "native-identity", nativeReference: "session:1" },
+      },
+      "identity-only"
+    ),
+    true
+  );
   assert.equal(sessionOpenEvidenceMatches(identity, "retained-history"), false);
   assert.equal(sessionOpenEvidenceMatches(history, "retained-history"), true);
   assert.equal(sessionOpenEvidenceMatches(history, "identity-only"), false);

--- a/packages/pi-tidy-bots/test/hermes-adapter.test.ts
+++ b/packages/pi-tidy-bots/test/hermes-adapter.test.ts
@@ -848,6 +848,8 @@ for (const text of ["hello", "[owned-worker]", "[fleet-send]"]) {
     const f = await setup();
     try {
       assert.equal(f.host.capabilities.sessions.load, true);
+      assert.equal(f.host.capabilities.sessions.proof, "retained-history");
+      assert.equal(f.host.capabilities.sessions.emptySeat, "non-restorable");
       assert.equal(
         f.host.capabilities.interactions.permissions,
         "exact-request"

--- a/packages/pi-tidy-bots/test/pi-adapter.test.ts
+++ b/packages/pi-tidy-bots/test/pi-adapter.test.ts
@@ -1226,7 +1226,14 @@ test("Pi cold load restores exact checkpoint across process replacement without 
     };
     const restored = (await second.request("session.open", load)) as JsonObject;
     assert.equal(restored.continuity, "verified");
+    assert.equal(restored.proof, "retained-history");
     assert.equal(restored.nativeReference, opened.nativeReference);
+    assert.deepEqual(restored.evidence, {
+      provenance: "pi-history-checkpoint",
+      sessionId: checkpoint.history.sessionId,
+      sessionFile: checkpoint.history.file,
+      messageCount: 1,
+    });
     assert.deepEqual(await second.request("session.open", load), restored);
     let effects = await f.effects();
     assert.equal(

--- a/packages/pi-tidy-bots/test/plugin-sdk-runtime.test.ts
+++ b/packages/pi-tidy-bots/test/plugin-sdk-runtime.test.ts
@@ -53,7 +53,7 @@ async function fixture(nativeProfile = false, sessionLoad = false) {
   if (sessionLoad)
     script = script.replace(
       'sessions: { load: false, import: false, continuity: "unverified" }',
-      'sessions: { load: true, import: false, continuity: "verified" }'
+      'sessions: { load: true, import: false, continuity: "verified", proof: "identity-only", emptySeat: "non-restorable" }'
     );
   await writeFile(
     join(artifact, "backend.mjs"),


### PR DESCRIPTION
## Summary

Astra P1-3 (continuity proof levels precise — don’t overclaim).

Protocol used to require `sessions.load/import` ⇒ `continuity: verified` without saying what was proved. Codex then labeled loads `verified` after expected home + returned thread id only. That is not Pi/Hermes retained-history verification.

### Proof levels

| Field | Meaning |
|---|---|
| `load` / `import` | Restore is attempted. Miss still fails closed; never silent `thread/start`. |
| `proof` | What a successful load actually proved. |
| `continuity: verified` | The advertised proof succeeded. Not a claim that every backend has history checkpoints. |
| `emptySeat` | Never-prompted seats. Current backends are `non-restorable`. |

Proof values:

- `none` — no restore advertised
- `identity-only` — Codex: isolated `CODEX_HOME` + exact thread id. No history digest, message count, or checkpoint comparison.
- `retained-history` — Pi: binding + history file + settings + `messageCount ≥ 1` + native session/file identity. Hermes: SessionDB checkpoint-v1 + metadata/session equality.

Never-prompted seats may remain explicitly non-restorable. Identity/fail-closed is the consistent perpetual-seat rule, not restart-availability for every new seat.

Load/import still requires `continuity: verified`, plus an explicit non-`none` proof and empty-seat policy.

### Proof

SHA: `48d527a100391b263bb189aba5230bb0a1103e3d`

Stacked on #77 @ `dd087fc` (`cursor/astra-p1-multi-item-e343`).

Commands (Node v26.7.0):

```
cd packages/pi-tidy-bots
node --import tsx --test --test-concurrency=2 \
  test/gateway-protocol.test.ts test/codex-adapter.test.ts \
  test/codex-session.test.ts test/pi-adapter.test.ts test/hermes-adapter.test.ts
# 73 tests, 73 pass, 0 fail

npm run check
# exit 0

npm test --workspace=@mobrienv/pi-tidy-bots
# 687 tests, 680 pass, 0 fail, 7 skipped
# exit 0
```

P1-1/P1-2 turn/item behavior unchanged.

### Out of scope

P1-4 `profile_dir` wire/drop.

### Hold

**HOLD MERGE for Hayes/Mikey.** Merge after #77. Prod `:4317` was not contacted.