### PR TITLE
fix(pi-tidy-bots): wire Codex profile_dir to CODEX_HOME (Astra P1-4)

### DIFF
--- a/packages/pi-tidy-bots/backends/codex/CAPABILITIES.md
+++ b/packages/pi-tidy-bots/backends/codex/CAPABILITIES.md
@@ -4,20 +4,25 @@ Honest descriptor until a named cell is proven. Chat Completions is not a
 control plane. This adapter speaks Codex app-server JSON-RPC (`initialize`,
 `thread/start`, `thread/resume`, `turn/start`, `turn/interrupt`).
 
-| Surface | Advertised | Status |
-|---|---|---|
-| Text open/submit/stream/close | yes | Fixture conformance |
-| Cancel | cooperative `turn/interrupt` | Fixture only |
-| Session load | `sessions.load=true` | Fail-closed on miss; never `thread/start` on load |
-| Continuity | `verified` | Means the advertised **identity-only** proof succeeded. Not Pi/Hermes retained-history verification. |
-| Proof | `identity-only` | Expected isolated `CODEX_HOME` plus the exact returned thread id. No history digest, message-count, or checkpoint comparison. |
-| Empty seat | `non-restorable` | Never-prompted / unprompted threads may lack a resumable rollout. They stay fail-closed; restart-availability is not claimed. |
-| Steer | false | Native `turn/steer` exists; unmapped |
-| Questions | false | No generic question cards |
-| Compact | false | Native `thread/compact` exists; unmapped |
-| Permissions | none | Approval requests fail closed; never auto-approve |
-| Fleet tools | false | Dual-backend Codex↔Pi fixture smoke is text-only |
-| Auth | native profile | `CODEX_HOME` / `auth.json` or named env keys. No secrets in manifest |
+| Surface                       | Advertised                   | Status                                                                                                                        |
+| ----------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Text open/submit/stream/close | yes                          | Fixture conformance                                                                                                           |
+| Cancel                        | cooperative `turn/interrupt` | Fixture only                                                                                                                  |
+| Session load                  | `sessions.load=true`         | Fail-closed on miss; never `thread/start` on load                                                                             |
+| Continuity                    | `verified`                   | Means the advertised **identity-only** proof succeeded. Not Pi/Hermes retained-history verification.                          |
+| Proof                         | `identity-only`              | Expected isolated `CODEX_HOME` plus the exact returned thread id. No history digest, message-count, or checkpoint comparison. |
+| Empty seat                    | `non-restorable`             | Never-prompted / unprompted threads may lack a resumable rollout. They stay fail-closed; restart-availability is not claimed. |
+| Steer                         | false                        | Native `turn/steer` exists; unmapped                                                                                          |
+| Questions                     | false                        | No generic question cards                                                                                                     |
+| Compact                       | false                        | Native `thread/compact` exists; unmapped                                                                                      |
+| Permissions                   | none                         | Approval requests fail closed; never auto-approve                                                                             |
+| Fleet tools                   | false                        | Dual-backend Codex↔Pi fixture smoke is text-only                                                                              |
+| Auth                          | native profile               | `CODEX_HOME` / `auth.json` or named env keys. No secrets in manifest                                                          |
+
+Launch split (same as Pi/Hermes): `HOME` is `home_dir`; isolated `CODEX_HOME`
+is `profile_dir`. Thread store and `initialize.codexHome` use the profile.
+Open diagnostics report both resolved non-secret paths. Changing `profile_dir`
+changes the native store; Unix `HOME` does not.
 
 Mikey invariant: fleet seats are perpetual. Identity/fail-closed is the
 consistent rule for every new seat — not restart-availability. Restart must

--- a/packages/pi-tidy-bots/backends/codex/CAPABILITIES.md
+++ b/packages/pi-tidy-bots/backends/codex/CAPABILITIES.md
@@ -9,7 +9,9 @@ control plane. This adapter speaks Codex app-server JSON-RPC (`initialize`,
 | Text open/submit/stream/close | yes | Fixture conformance |
 | Cancel | cooperative `turn/interrupt` | Fixture only |
 | Session load | `sessions.load=true` | Fail-closed on miss; never `thread/start` on load |
-| Continuity | `verified` | Protocol requires this when load is advertised. Fixture reload proved same thread id. Native Codex `thread/resume` across a real app-server restart PASSed (`test/codex-native-smoke.test.ts`, log `/tmp/tidy-codex-197-native-smoke.log`). |
+| Continuity | `verified` | Means the advertised **identity-only** proof succeeded. Not Pi/Hermes retained-history verification. |
+| Proof | `identity-only` | Expected isolated `CODEX_HOME` plus the exact returned thread id. No history digest, message-count, or checkpoint comparison. |
+| Empty seat | `non-restorable` | Never-prompted / unprompted threads may lack a resumable rollout. They stay fail-closed; restart-availability is not claimed. |
 | Steer | false | Native `turn/steer` exists; unmapped |
 | Questions | false | No generic question cards |
 | Compact | false | Native `thread/compact` exists; unmapped |
@@ -17,6 +19,8 @@ control plane. This adapter speaks Codex app-server JSON-RPC (`initialize`,
 | Fleet tools | false | Dual-backend Codex↔Pi fixture smoke is text-only |
 | Auth | native profile | `CODEX_HOME` / `auth.json` or named env keys. No secrets in manifest |
 
-Mikey invariant: fleet seats are perpetual. Restart must `thread/resume` the
-same native thread or fail closed. Empty never-prompted threads have no
-rollout and stay fail-closed (no silent `thread/start`).
+Mikey invariant: fleet seats are perpetual. Identity/fail-closed is the
+consistent rule for every new seat — not restart-availability. Restart must
+`thread/resume` the same native thread or fail closed. Empty never-prompted
+threads have no rollout and stay explicitly `non-restorable` (no silent
+`thread/start`).

--- a/packages/pi-tidy-bots/backends/codex/adapter.ts
+++ b/packages/pi-tidy-bots/backends/codex/adapter.ts
@@ -18,11 +18,18 @@ import {
   type CodexRuntime,
 } from "./runtime.ts";
 
-// Protocol requires load ⇒ verified. Fixture reload proved same-thread
-// resume and fail-closed miss. Native Codex reload smoke is still not-run.
+// Load is fail-closed identity proof only: isolated home + exact thread id.
+// That is not Pi/Hermes retained-history verification. Never-prompted seats
+// stay non-restorable (Codex unprompted threads may lack a resumable rollout).
 export const CODEX_CAPABILITIES: CapabilityDescriptor = {
   input: { text: true, mediaTypes: [], maxMediaBytes: 0 },
-  sessions: { load: true, import: false, continuity: "verified" },
+  sessions: {
+    load: true,
+    import: false,
+    continuity: "verified",
+    proof: "identity-only",
+    emptySeat: "non-restorable",
+  },
   output: { text: "snapshots", tools: false, usage: "unknown" },
   operations: {
     nativeDedupe: "none",
@@ -158,6 +165,16 @@ export function startCodexAdapter(): PluginRuntime {
           status: "opened",
           nativeReference: `codex:${native.nativeReference}`,
           continuity: params.mode === "load" ? "verified" : "unverified",
+          proof: params.mode === "load" ? "identity-only" : "none",
+          ...(params.mode === "load"
+            ? {
+                evidence: {
+                  provenance: "codex-thread-identity",
+                  expectedHome: true,
+                  threadId: native.nativeReference,
+                },
+              }
+            : {}),
         };
       },
       async "operation.submit"(params, ctx) {

--- a/packages/pi-tidy-bots/backends/codex/adapter.ts
+++ b/packages/pi-tidy-bots/backends/codex/adapter.ts
@@ -18,7 +18,8 @@ import {
   type CodexRuntime,
 } from "./runtime.ts";
 
-// Load is fail-closed identity proof only: isolated home + exact thread id.
+// Load is fail-closed identity proof only: isolated CODEX_HOME
+// (profile_dir, not Unix HOME) + exact thread id.
 // That is not Pi/Hermes retained-history verification. Never-prompted seats
 // stay non-restorable (Codex unprompted threads may lack a resumable rollout).
 export const CODEX_CAPABILITIES: CapabilityDescriptor = {
@@ -166,11 +167,13 @@ export function startCodexAdapter(): PluginRuntime {
           nativeReference: `codex:${native.nativeReference}`,
           continuity: params.mode === "load" ? "verified" : "unverified",
           proof: params.mode === "load" ? "identity-only" : "none",
+          diagnostics: native.diagnostics,
           ...(params.mode === "load"
             ? {
                 evidence: {
                   provenance: "codex-thread-identity",
                   expectedHome: true,
+                  codexHome: native.diagnostics.codexHome,
                   threadId: native.nativeReference,
                 },
               }

--- a/packages/pi-tidy-bots/backends/codex/config.schema.json
+++ b/packages/pi-tidy-bots/backends/codex/config.schema.json
@@ -5,8 +5,16 @@
   "required": ["executable", "home_dir", "profile_dir", "environment_keys"],
   "properties": {
     "executable": { "type": "string", "pattern": "^/" },
-    "home_dir": { "type": "string", "pattern": "^/" },
-    "profile_dir": { "type": "string", "pattern": "^/" },
+    "home_dir": {
+      "type": "string",
+      "pattern": "^/",
+      "description": "Unix HOME for the Codex child. Not the native thread store."
+    },
+    "profile_dir": {
+      "type": "string",
+      "pattern": "^/",
+      "description": "Isolated CODEX_HOME. initialize.codexHome and thread store. Distinct from home_dir."
+    },
     "environment_keys": {
       "type": "array",
       "uniqueItems": true,

--- a/packages/pi-tidy-bots/backends/codex/runtime.ts
+++ b/packages/pi-tidy-bots/backends/codex/runtime.ts
@@ -20,6 +20,12 @@ export interface CodexConfiguration {
   environment: Record<string, string>;
 }
 
+/** Non-secret launch locations. HOME is Unix home; CODEX_HOME is profile_dir. */
+export interface CodexRuntimeDiagnostics {
+  home: string;
+  codexHome: string;
+}
+
 const keys = ["executable", "home_dir", "profile_dir", "environment_keys"];
 const absolute = (value: unknown): value is string =>
   nonempty(value) && isAbsolute(value) && !value.includes("\0");
@@ -70,7 +76,8 @@ export async function validateCodexConfiguration(
       executable,
       home,
       profile,
-      environment: { ...environment, HOME: home, CODEX_HOME: home },
+      // Same split as Pi/Hermes: HOME is Unix home, native store is profile.
+      environment: { ...environment, HOME: home, CODEX_HOME: profile },
     };
   } catch {
     throw new ProtocolError(
@@ -84,6 +91,7 @@ export interface CodexRuntime {
   session: CodexSession;
   nativeReference: string;
   launchId: string;
+  diagnostics: CodexRuntimeDiagnostics;
   closed: Promise<void>;
   close(): Promise<void>;
   cancel(params: JsonObject): unknown;
@@ -133,7 +141,8 @@ export async function openCodexRuntime(
       maxPendingRequests: ctx.initialization.limits.maxPendingRequests,
       requestTimeoutMs: ctx.initialization.limits.commandTimeoutMs,
       promptTimeoutMs: 3600000,
-      expectedHome: configuration.home,
+      // initialize.codexHome must match isolated CODEX_HOME (profile_dir).
+      expectedHome: configuration.profile,
       emit: (event) => ctx.emit(event as EventInput),
       onFailure,
     });
@@ -146,6 +155,10 @@ export async function openCodexRuntime(
       session,
       nativeReference,
       launchId,
+      diagnostics: {
+        home: configuration.home,
+        codexHome: configuration.profile,
+      },
       closed: process.closed,
       close,
       cancel: (params) => {

--- a/packages/pi-tidy-bots/backends/codex/session.ts
+++ b/packages/pi-tidy-bots/backends/codex/session.ts
@@ -13,18 +13,24 @@ import {
 
 type Execution = "ended" | "failed" | "cancelled" | "interrupted";
 
+interface ItemMessage {
+  nativeItemId: string;
+  id: string;
+  text: string;
+  revision: number;
+  finished: boolean;
+}
+
 interface Turn {
   operationId: string;
   turnId: string;
   nativeTurnId?: string;
-  nativeItemId?: string;
   started: boolean;
   cancelRequested?: boolean;
   onAccepted?: () => void;
   settle?: (execution: Execution) => void;
   order: number;
-  text: string;
-  message?: { id: string; text: string; revision: number };
+  items: Map<string, ItemMessage>;
 }
 
 const LIVE_STATUS = new Set(["inProgress", "in_progress"]);
@@ -189,7 +195,7 @@ export class CodexSession {
       turnId,
       started: false,
       order: 0,
-      text: "",
+      items: new Map(),
       onAccepted,
     };
     this.active = turn;
@@ -229,7 +235,7 @@ export class CodexSession {
           this.active = undefined;
           return { disposition: turn.started ? "accepted" : "unknown" };
         }
-        this.finishMessage(turn);
+        this.finishOpenItems(turn);
         this.emit(turn, "turn.terminal", {
           execution,
           observation: "complete",
@@ -309,19 +315,32 @@ export class CodexSession {
       return;
     }
     if (!turn.nativeTurnId || notificationTurnId !== turn.nativeTurnId) return;
-    if (method.startsWith("item/")) {
-      const itemId = nativeItemIdOf(params);
-      if (!itemId) return;
-      if (turn.nativeItemId && turn.nativeItemId !== itemId) return;
-      turn.nativeItemId = itemId;
+    if (!method.startsWith("item/")) {
+      if (method === "turn/completed" && object(params.turn)) {
+        const execution = terminalExecution(
+          params.turn.status,
+          !!turn.cancelRequested
+        );
+        if (!execution)
+          throw new ProtocolError(
+            "native_observation_gap",
+            "Codex turn status is not an allowlisted terminal"
+          );
+        this.complete(turn, execution);
+      }
+      return;
     }
+    const itemId = nativeItemIdOf(params);
+    if (!itemId) return;
     if (
       method === "item/agentMessage/delta" &&
       typeof params.delta === "string" &&
       params.delta
     ) {
+      const item = this.itemOf(turn, itemId);
+      if (item.finished) return;
       this.started(turn);
-      this.snapshot(turn, turn.text + params.delta);
+      this.snapshot(item, turn, item.text + params.delta);
       return;
     }
     if (
@@ -329,23 +348,15 @@ export class CodexSession {
       object(params.item)
     ) {
       const text = agentText(params.item);
+      const item = text
+        ? this.itemOf(turn, itemId)
+        : turn.items.get(itemId);
+      if (!item || item.finished) return;
       if (text) {
         this.started(turn);
-        this.snapshot(turn, text);
+        this.snapshot(item, turn, text);
       }
-      return;
-    }
-    if (method === "turn/completed" && object(params.turn)) {
-      const execution = terminalExecution(
-        params.turn.status,
-        !!turn.cancelRequested
-      );
-      if (!execution)
-        throw new ProtocolError(
-          "native_observation_gap",
-          "Codex turn status is not an allowlisted terminal"
-        );
-      this.complete(turn, execution);
+      if (method === "item/completed") this.finishItem(item, turn);
     }
   }
   private complete(turn: Turn, execution: Execution): void {
@@ -376,34 +387,43 @@ export class CodexSession {
     turn.started = true;
     turn.onAccepted?.();
   }
-  private snapshot(turn: Turn, text: string): void {
+  private itemOf(turn: Turn, nativeItemId: string): ItemMessage {
+    const existing = turn.items.get(nativeItemId);
+    if (existing) return existing;
+    const item: ItemMessage = {
+      nativeItemId,
+      id: `${turn.operationId}:message:${turn.order}`,
+      text: "",
+      revision: 0,
+      finished: false,
+    };
+    turn.items.set(nativeItemId, item);
+    return item;
+  }
+  private snapshot(item: ItemMessage, turn: Turn, text: string): void {
+    if (item.finished) return;
     if (Buffer.byteLength(text) > 512 * 1024) throw new Error();
-    if (!turn.message) {
+    if (!item.revision) {
       const order = turn.order++;
-      turn.message = {
-        id: `${turn.operationId}:message:${order}`,
-        text: "",
-        revision: 0,
-      };
+      item.id = `${turn.operationId}:message:${order}`;
       this.emit(
         turn,
         "message.started",
         { role: "assistant", order },
-        { messageId: turn.message.id }
+        { messageId: item.id }
       );
     }
-    turn.text = text;
-    turn.message.text = text;
+    item.text = text;
     this.emit(
       turn,
       "text.snapshot",
-      { text, revision: ++turn.message.revision },
-      { messageId: turn.message.id, blockId: "body" }
+      { text, revision: ++item.revision },
+      { messageId: item.id, blockId: "body" }
     );
   }
-  private finishMessage(turn: Turn): void {
-    if (!turn.message) return;
-    const message = turn.message;
+  private finishItem(item: ItemMessage, turn: Turn): void {
+    if (item.finished || !item.revision) return;
+    item.finished = true;
     this.emit(
       turn,
       "message.finished",
@@ -413,14 +433,16 @@ export class CodexSession {
           {
             type: "text",
             blockId: "body",
-            text: message.text,
-            revision: message.revision,
+            text: item.text,
+            revision: item.revision,
           },
         ],
       },
-      { messageId: message.id }
+      { messageId: item.id }
     );
-    turn.message = undefined;
+  }
+  private finishOpenItems(turn: Turn): void {
+    for (const item of turn.items.values()) this.finishItem(item, turn);
   }
   private fail(error: ProtocolError): void {
     if (this.lost) return;

--- a/packages/pi-tidy-bots/backends/codex/session.ts
+++ b/packages/pi-tidy-bots/backends/codex/session.ts
@@ -69,6 +69,7 @@ export interface CodexSessionOptions extends Pick<
   | "requestTimeoutMs"
 > {
   promptTimeoutMs?: number;
+  /** Isolated CODEX_HOME (`profile_dir`). Not Unix HOME (`home_dir`). */
   expectedHome: string;
   emit: (event: JsonObject) => void;
   onFailure: (error: ProtocolError) => void;
@@ -155,7 +156,7 @@ export class CodexSession {
           "continuity_unverified",
           "Codex load did not restore the exact retained thread"
         );
-      // Identity-only: expected home + returned thread id. No history
+      // Identity-only: expected CODEX_HOME + returned thread id. No history
       // digest, message count, or checkpoint comparison is available.
       this.threadId = resumedId;
       return this.threadId;
@@ -213,7 +214,11 @@ export class CodexSession {
         },
         this.options.requestTimeoutMs
       );
-      if (!object(started) || !object(started.turn) || !nonempty(started.turn.id))
+      if (
+        !object(started) ||
+        !object(started.turn) ||
+        !nonempty(started.turn.id)
+      )
         throw new Error();
       turn.nativeTurnId = String(started.turn.id);
       this.started(turn);
@@ -228,7 +233,10 @@ export class CodexSession {
         this.complete(turn, execution);
       }
       const timeout = setTimeout(
-        () => this.fail(new ProtocolError("native_timeout", "Codex turn timed out")),
+        () =>
+          this.fail(
+            new ProtocolError("native_timeout", "Codex turn timed out")
+          ),
         this.options.promptTimeoutMs ?? 3600000
       );
       try {
@@ -350,9 +358,7 @@ export class CodexSession {
       object(params.item)
     ) {
       const text = agentText(params.item);
-      const item = text
-        ? this.itemOf(turn, itemId)
-        : turn.items.get(itemId);
+      const item = text ? this.itemOf(turn, itemId) : turn.items.get(itemId);
       if (!item || item.finished) return;
       if (text) {
         this.started(turn);

--- a/packages/pi-tidy-bots/backends/codex/session.ts
+++ b/packages/pi-tidy-bots/backends/codex/session.ts
@@ -155,6 +155,8 @@ export class CodexSession {
           "continuity_unverified",
           "Codex load did not restore the exact retained thread"
         );
+      // Identity-only: expected home + returned thread id. No history
+      // digest, message count, or checkpoint comparison is available.
       this.threadId = resumedId;
       return this.threadId;
     }

--- a/packages/pi-tidy-bots/backends/hermes/adapter.ts
+++ b/packages/pi-tidy-bots/backends/hermes/adapter.ts
@@ -27,7 +27,13 @@ export const HERMES_CAPABILITIES: CapabilityDescriptor = {
     mediaTypes: ["text/plain", "image/png", "image/jpeg"],
     maxMediaBytes: 512 * 1024,
   },
-  sessions: { load: true, import: false, continuity: "verified" },
+  sessions: {
+    load: true,
+    import: false,
+    continuity: "verified",
+    proof: "retained-history",
+    emptySeat: "non-restorable",
+  },
   output: { text: "snapshots", tools: true, usage: "unknown" },
   operations: {
     nativeDedupe: "none",
@@ -170,6 +176,15 @@ export function startHermesAdapter(): PluginRuntime {
           status: "opened",
           nativeReference: `hermes:${native.nativeReference}`,
           continuity: params.mode === "load" ? "verified" : "unverified",
+          proof: params.mode === "load" ? "retained-history" : "none",
+          ...(params.mode === "load"
+            ? {
+                evidence: {
+                  provenance: "hermes-checkpoint-v1",
+                  sessionId: native.nativeReference,
+                },
+              }
+            : {}),
         };
       },
       async "operation.submit"(params, ctx) {

--- a/packages/pi-tidy-bots/backends/pi/adapter.ts
+++ b/packages/pi-tidy-bots/backends/pi/adapter.ts
@@ -31,13 +31,21 @@ import {
 } from "@mobrienv/pi-tidy-bots/src/rpc.ts";
 
 // Expand this profile only after its native feature conformance cells pass.
+// Load proof is retained-history (binding + file + settings + messageCount).
+// Empty never-prompted seats stay non-restorable: checkpoint requires ≥1 message.
 export const PI_CAPABILITIES: CapabilityDescriptor = {
   input: {
     text: true,
     mediaTypes: ["text/plain", "image/png", "image/jpeg"],
     maxMediaBytes: 512 * 1024,
   },
-  sessions: { load: true, import: false, continuity: "verified" },
+  sessions: {
+    load: true,
+    import: false,
+    continuity: "verified",
+    proof: "retained-history",
+    emptySeat: "non-restorable",
+  },
   output: { text: "snapshots", tools: true, usage: "unknown" },
   operations: {
     nativeDedupe: "none",
@@ -778,6 +786,17 @@ export function startPiAdapter(): PluginRuntime {
           status: "opened",
           nativeReference,
           continuity: checkpoint ? "verified" : "unverified",
+          proof: checkpoint ? "retained-history" : "none",
+          ...(checkpoint
+            ? {
+                evidence: {
+                  provenance: "pi-history-checkpoint",
+                  sessionId: checkpoint.history.sessionId,
+                  sessionFile: checkpoint.history.file,
+                  messageCount: checkpoint.messageCount,
+                },
+              }
+            : {}),
         };
       },
       async "session.snapshot"(params) {

--- a/packages/pi-tidy-bots/src/gateway/application.ts
+++ b/packages/pi-tidy-bots/src/gateway/application.ts
@@ -38,6 +38,8 @@ import {
 import {
   object,
   ProtocolError,
+  sessionOpenEvidenceMatches,
+  sessionProofOf,
   type CapabilityDescriptor,
   type GatewayPluginEvent,
 } from "./protocol.ts";
@@ -124,6 +126,11 @@ function effectiveCapabilities(
         native.sessions.load && native.sessions.continuity === "verified"
           ? "verified"
           : "unverified",
+      proof:
+        native.sessions.load && native.sessions.continuity === "verified"
+          ? (native.sessions.proof ?? "none")
+          : "none",
+      emptySeat: native.sessions.emptySeat ?? "non-restorable",
     },
     output: {
       text: native.output.text,
@@ -659,7 +666,12 @@ export class GatewayApplication {
         response.status !== "opened" ||
         (existing &&
           (response.nativeReference !== nativeReference ||
-            response.continuity !== "verified"))
+            response.continuity !== "verified" ||
+            response.proof !== sessionProofOf(capabilities.sessions) ||
+            !sessionOpenEvidenceMatches(
+              response,
+              sessionProofOf(capabilities.sessions)
+            )))
       ) {
         observeOpenFailure(
           object(response) && response.status === "creation_unknown"

--- a/packages/pi-tidy-bots/src/gateway/protocol.ts
+++ b/packages/pi-tidy-bots/src/gateway/protocol.ts
@@ -153,12 +153,29 @@ export class FrameDecoder {
   }
 }
 
+export type SessionProof = "none" | "identity-only" | "retained-history";
+export type EmptySeatPolicy = "non-restorable" | "restartable";
+export type ContinuityStatus = "verified" | "unverified";
+export type SessionEvidenceProvenance =
+  | "codex-thread-identity"
+  | "pi-history-checkpoint"
+  | "hermes-checkpoint-v1";
+
+/** Load support, proof type, and evidence provenance are distinct.
+ * `load`/`import` mean restore is attempted. `proof` is what a successful
+ * load actually proved. `continuity: verified` means that advertised proof
+ * succeeded — not that every backend has Pi/Hermes-equivalent history.
+ * Never-prompted seats may stay `emptySeat: non-restorable`; fail closed
+ * rather than invent restart-availability.
+ */
 export interface CapabilityDescriptor {
   input: { text: true; mediaTypes: string[]; maxMediaBytes: number };
   sessions: {
     load: boolean;
     import: boolean;
-    continuity: "verified" | "unverified";
+    continuity: ContinuityStatus;
+    proof?: SessionProof;
+    emptySeat?: EmptySeatPolicy;
   };
   output: {
     text: "final-only" | "snapshots";
@@ -371,7 +388,7 @@ export function validateCapabilities(value: unknown): CapabilityDescriptor {
   if (!object(value)) return fail("Missing capabilities");
   const sections: Record<string, string[]> = {
     input: ["text", "mediaTypes", "maxMediaBytes"],
-    sessions: ["load", "import", "continuity"],
+    sessions: ["load", "import", "continuity", "proof", "emptySeat"],
     output: ["text", "tools", "usage"],
     operations: [
       "nativeDedupe",
@@ -446,6 +463,25 @@ export function validateCapabilities(value: unknown): CapabilityDescriptor {
   ];
   if (enums.some(([entry, allowed]) => !allowed.includes(String(entry))))
     return fail("Unknown capability value");
+  const restore = descriptor.sessions.load || descriptor.sessions.import;
+  const proof = descriptor.sessions.proof ?? "none";
+  if (!["none", "identity-only", "retained-history"].includes(proof))
+    return fail("Unknown session proof");
+  if (
+    descriptor.sessions.emptySeat !== undefined &&
+    descriptor.sessions.emptySeat !== "non-restorable" &&
+    descriptor.sessions.emptySeat !== "restartable"
+  )
+    return fail("Unknown empty-seat policy");
+  if (restore) {
+    if (descriptor.sessions.continuity !== "verified")
+      return fail("Session restoration requires verified continuity");
+    if (proof === "none")
+      return fail("Session restoration requires an explicit proof level");
+    if (descriptor.sessions.emptySeat === undefined)
+      return fail("Session restoration requires an explicit empty-seat policy");
+  } else if (proof !== "none")
+    return fail("Proof without load or import overclaims restoration");
   const positive = (entry: unknown) =>
     Number.isSafeInteger(entry) && Number(entry) > 0;
   if (
@@ -459,10 +495,36 @@ export function validateCapabilities(value: unknown): CapabilityDescriptor {
       descriptor.operations.nativeReplayGapSemantics !== "explicit-gap")
   )
     return fail("Cursor replay requires retention and explicit gap semantics");
-  if (
-    (descriptor.sessions.load || descriptor.sessions.import) &&
-    descriptor.sessions.continuity !== "verified"
-  )
-    return fail("Session restoration requires verified continuity");
   return descriptor;
+}
+
+export function sessionProofOf(
+  sessions: CapabilityDescriptor["sessions"]
+): SessionProof {
+  return sessions.proof ?? "none";
+}
+
+export function emptySeatOf(
+  sessions: CapabilityDescriptor["sessions"]
+): EmptySeatPolicy {
+  return sessions.emptySeat ?? "non-restorable";
+}
+
+export function sessionOpenEvidenceMatches(
+  result: JsonObject,
+  advertised: SessionProof
+): boolean {
+  if (advertised === "none")
+    return result.proof === "none" || result.proof === undefined;
+  if (result.continuity !== "verified" || result.proof !== advertised)
+    return false;
+  if (!object(result.evidence) || !nonempty(result.evidence.provenance))
+    return false;
+  const provenance = String(result.evidence.provenance);
+  if (advertised === "identity-only")
+    return provenance === "codex-thread-identity";
+  return (
+    provenance === "pi-history-checkpoint" ||
+    provenance === "hermes-checkpoint-v1"
+  );
 }

--- a/packages/pi-tidy-bots/src/gateway/protocol.ts
+++ b/packages/pi-tidy-bots/src/gateway/protocol.ts
@@ -157,6 +157,7 @@ export type SessionProof = "none" | "identity-only" | "retained-history";
 export type EmptySeatPolicy = "non-restorable" | "restartable";
 export type ContinuityStatus = "verified" | "unverified";
 export type SessionEvidenceProvenance =
+  | "native-identity"
   | "codex-thread-identity"
   | "pi-history-checkpoint"
   | "hermes-checkpoint-v1";
@@ -522,7 +523,10 @@ export function sessionOpenEvidenceMatches(
     return false;
   const provenance = String(result.evidence.provenance);
   if (advertised === "identity-only")
-    return provenance === "codex-thread-identity";
+    return (
+      provenance !== "pi-history-checkpoint" &&
+      provenance !== "hermes-checkpoint-v1"
+    );
   return (
     provenance === "pi-history-checkpoint" ||
     provenance === "hermes-checkpoint-v1"

--- a/packages/pi-tidy-bots/src/gateway/schema/capabilities.schema.json
+++ b/packages/pi-tidy-bots/src/gateway/schema/capabilities.schema.json
@@ -50,7 +50,16 @@
           "type": "boolean"
         },
         "continuity": {
-          "enum": ["verified", "unverified"]
+          "enum": ["verified", "unverified"],
+          "description": "Whether this adapter's advertised proof succeeded. Not a claim that every backend has retained-history verification."
+        },
+        "proof": {
+          "enum": ["none", "identity-only", "retained-history"],
+          "description": "What a successful load actually proved. identity-only is not Pi/Hermes-equivalent history verification."
+        },
+        "emptySeat": {
+          "enum": ["non-restorable", "restartable"],
+          "description": "Never-prompted seats may remain explicitly non-restorable. Fail closed rather than invent restart-availability."
         }
       },
       "required": ["load", "import", "continuity"],
@@ -94,9 +103,16 @@
             ]
           },
           "then": {
+            "required": ["proof", "emptySeat"],
             "properties": {
               "continuity": {
                 "const": "verified"
+              },
+              "proof": {
+                "enum": ["identity-only", "retained-history"]
+              },
+              "emptySeat": {
+                "enum": ["non-restorable", "restartable"]
               }
             }
           }

--- a/packages/pi-tidy-bots/test/codex-adapter.test.ts
+++ b/packages/pi-tidy-bots/test/codex-adapter.test.ts
@@ -7,6 +7,7 @@ import {
   copyFile,
   mkdir,
   mkdtemp,
+  realpath,
   rm,
   symlink,
   writeFile,
@@ -49,7 +50,7 @@ async function setup(
     profile = join(dir, "profile");
   await mkdir(home);
   await mkdir(profile);
-  if (extras.lieHome) await writeFile(join(home, "lie-home"), "1\n");
+  if (extras.lieHome) await writeFile(join(profile, "lie-home"), "1\n");
   const executable = join(dir, "codex-fixture");
   await copyFile(fixtureExecutable, executable);
   await chmod(executable, 0o755);
@@ -202,7 +203,9 @@ test("packed Codex artifact contains its executable contract and runs after extr
         .execution,
       "ended"
     );
-    const snapshots = f.events.filter((event) => event.type === "text.snapshot");
+    const snapshots = f.events.filter(
+      (event) => event.type === "text.snapshot"
+    );
     assert.ok(snapshots.length >= 1);
     assert.equal(
       snapshots[snapshots.length - 1]!.payload.text,
@@ -221,23 +224,29 @@ test("Codex open/submit/stream/close uses app-server not Chat Completions", asyn
       nativeReference: string;
       continuity: string;
       proof: string;
+      diagnostics?: { home?: string; codexHome?: string };
     };
     assert.match(opened.nativeReference, /^codex:thr-fixture-/);
     assert.equal(opened.continuity, "unverified");
     assert.equal(opened.proof, "none");
+    assert.deepEqual(opened.diagnostics, {
+      home: await realpath(f.home),
+      codexHome: await realpath(f.profile),
+    });
+    assert.notEqual(opened.diagnostics!.home, opened.diagnostics!.codexHome);
     assert.equal(f.host.capabilities.sessions.proof, "identity-only");
     assert.equal(f.host.capabilities.sessions.emptySeat, "non-restorable");
     assert.notEqual(f.host.capabilities.sessions.proof, "retained-history");
     // New sessions stay unverified. Load proof is identity-only, not history.
     assert.equal(
-      ((await f.host.request("operation.submit", f.submit("hello"))) as {
-        disposition: string;
-      }).disposition,
+      (
+        (await f.host.request("operation.submit", f.submit("hello"))) as {
+          disposition: string;
+        }
+      ).disposition,
       "accepted"
     );
-    await until(() =>
-      f.events.some((event) => event.type === "turn.terminal")
-    );
+    await until(() => f.events.some((event) => event.type === "turn.terminal"));
     assert.ok(f.events.some((event) => event.type === "turn.started"));
     assert.ok(f.events.some((event) => event.type === "text.snapshot"));
     assert.equal(
@@ -263,9 +272,7 @@ test("two Codex assistant items stay two finished messages", async () => {
       ).disposition,
       "accepted"
     );
-    await until(() =>
-      f.events.some((event) => event.type === "turn.terminal")
-    );
+    await until(() => f.events.some((event) => event.type === "turn.terminal"));
     const finished = f.events.filter(
       (event) => event.type === "message.finished"
     );
@@ -303,16 +310,18 @@ test("stale Codex turn completion does not invent a terminal for the live turn",
       ).disposition,
       "accepted"
     );
-    await until(() =>
-      f.events.some((event) => event.type === "turn.terminal")
+    await until(() => f.events.some((event) => event.type === "turn.terminal"));
+    const terminals = f.events.filter(
+      (event) => event.type === "turn.terminal"
     );
-    const terminals = f.events.filter((event) => event.type === "turn.terminal");
     assert.equal(terminals.length, 1);
     assert.equal(terminals[0]!.operationId, "op1");
     assert.equal(terminals[0]!.turnId, "turn1");
     assert.equal(terminals[0]!.payload.execution, "ended");
     assert.equal(terminals[0]!.payload.observation, "complete");
-    const snapshots = f.events.filter((event) => event.type === "text.snapshot");
+    const snapshots = f.events.filter(
+      (event) => event.type === "text.snapshot"
+    );
     assert.equal(
       snapshots[snapshots.length - 1]!.payload.text,
       "codex:[stale-turn]"
@@ -367,9 +376,7 @@ test("Codex cancel losing the race to native completed keeps the receipt complet
       "operation.submit",
       f.submit("[cancel-then-completed]")
     );
-    await until(() =>
-      f.events.some((event) => event.type === "turn.started")
-    );
+    await until(() => f.events.some((event) => event.type === "turn.started"));
     const result = await f.host.request("operation.cancel", {
       operationId: "cancel1",
       targetOperationId: "op1",
@@ -401,9 +408,7 @@ test("Codex cancel is cooperative turn/interrupt and not terminal proof", async 
       "operation.submit",
       f.submit("[cancel-hold]")
     );
-    await until(() =>
-      f.events.some((event) => event.type === "turn.started")
-    );
+    await until(() => f.events.some((event) => event.type === "turn.started"));
     const cancel = {
       operationId: "cancel1",
       targetOperationId: "op1",
@@ -430,9 +435,7 @@ test("Codex load restores the same native thread across adapter restart", async 
       nativeReference: string;
     };
     await f.host.request("operation.submit", f.submit("remember"));
-    await until(() =>
-      f.events.some((event) => event.type === "turn.terminal")
-    );
+    await until(() => f.events.some((event) => event.type === "turn.terminal"));
     await f.host.close();
     const registry = join(f.dir, "registry.json");
     const installation = (
@@ -482,7 +485,11 @@ test("Codex load restores the same native thread across adapter restart", async 
         nativeReference: string;
         continuity: string;
         proof: string;
-        evidence?: { provenance?: string; threadId?: string };
+        evidence?: {
+          provenance?: string;
+          threadId?: string;
+          codexHome?: string;
+        };
       };
       assert.equal(loaded.nativeReference, first.nativeReference);
       assert.equal(loaded.continuity, "verified");
@@ -491,6 +498,7 @@ test("Codex load restores the same native thread across adapter restart", async 
       assert.deepEqual(loaded.evidence, {
         provenance: "codex-thread-identity",
         expectedHome: true,
+        codexHome: await realpath(f.profile),
         threadId: first.nativeReference.slice("codex:".length),
       });
       assert.equal(reload.capabilities.sessions.proof, "identity-only");
@@ -526,6 +534,7 @@ test("Codex load miss fails closed and never starts a fresh thread", async () =>
       }),
       { code: "session_not_found" }
     );
+    assert.equal(existsSync(join(f.profile, "threads.json")), false);
     assert.equal(existsSync(join(f.home, "threads.json")), false);
   } finally {
     await f.cleanup();
@@ -538,7 +547,80 @@ test("Codex initialize home mismatch fails closed", async () => {
     await assert.rejects(f.host.request("session.open", f.open), {
       code: "continuity_unverified",
     });
+    assert.equal(existsSync(join(f.profile, "threads.json")), false);
     assert.equal(existsSync(join(f.home, "threads.json")), false);
+  } finally {
+    await f.cleanup();
+  }
+});
+
+test("distinct Codex profile_dir is CODEX_HOME; other profile rejects load", async () => {
+  const f = await setup();
+  try {
+    const first = (await f.host.request("session.open", f.open)) as {
+      nativeReference: string;
+      diagnostics?: { home?: string; codexHome?: string };
+    };
+    assert.deepEqual(first.diagnostics, {
+      home: await realpath(f.home),
+      codexHome: await realpath(f.profile),
+    });
+    await f.host.request("operation.submit", f.submit("remember-profile"));
+    await until(() => f.events.some((event) => event.type === "turn.terminal"));
+    assert.equal(existsSync(join(f.profile, "threads.json")), true);
+    assert.equal(existsSync(join(f.home, "threads.json")), false);
+    await f.host.close();
+    const otherProfile = join(f.dir, "other-profile");
+    await mkdir(otherProfile);
+    const registry = join(f.dir, "registry.json");
+    const installation = (
+      await PluginRegistry.load(registry, {
+        policy: {
+          workspace: "read-write",
+          nativeProfile: true,
+          network: true,
+          gatewayTools: [],
+        },
+      })
+    ).resolve("tidy.codex");
+    const miss = await PluginHost.start({
+      installation,
+      bindingId: "codex-binding",
+      leaseGeneration: 2,
+      workspace: f.dir,
+      dataDir: join(f.dir, "data-other-profile"),
+      allowedEnv: { PATH: dirname(process.execPath) },
+      config: {
+        executable: f.executable,
+        home_dir: f.home,
+        profile_dir: otherProfile,
+        environment_keys: ["PATH"],
+      },
+      onEvent: async (event) => event.sourceSequence,
+      onHostCall: async () => ({
+        status: "admitted",
+        dispatchId: "fixture-dispatch",
+      }),
+      onLaunchPrepared: () => {},
+      onLaunchRecorded: () => {},
+      onLaunchStopped: () => {},
+    });
+    try {
+      await assert.rejects(
+        miss.request("session.open", {
+          ...f.open,
+          openId: "open-other",
+          operationId: "opening-other",
+          mode: "load",
+          nativeReference: first.nativeReference,
+        }),
+        { code: "session_not_found" }
+      );
+      assert.equal(existsSync(join(otherProfile, "threads.json")), false);
+      assert.equal(existsSync(join(f.profile, "threads.json")), true);
+    } finally {
+      await miss.close();
+    }
   } finally {
     await f.cleanup();
   }
@@ -649,7 +731,10 @@ test("disposable dual-backend Codex and Pi fixture smoke stays off 4317", async 
           bindingRevision?: string;
           conversationId?: string;
           backend?: { id?: string };
-          capabilities?: { fleetTools?: boolean; sessions?: { load?: boolean } };
+          capabilities?: {
+            fleetTools?: boolean;
+            sessions?: { load?: boolean };
+          };
           execution?: string;
         },
       };

--- a/packages/pi-tidy-bots/test/codex-adapter.test.ts
+++ b/packages/pi-tidy-bots/test/codex-adapter.test.ts
@@ -25,6 +25,13 @@ const fixtureExecutable = fileURLToPath(
   new URL("./fixtures/codex-native/app-server.mjs", import.meta.url)
 );
 
+function finishedText(event: GatewayPluginEvent): string {
+  const blocks = event.payload.blocks;
+  if (!Array.isArray(blocks)) return "";
+  const block = blocks[0] as { text?: unknown } | undefined;
+  return typeof block?.text === "string" ? block.text : "";
+}
+
 async function until(probe: () => boolean | Promise<boolean>) {
   const deadline = Date.now() + 8000;
   while (!(await probe())) {
@@ -261,8 +268,8 @@ test("two Codex assistant items stay two finished messages", async () => {
     assert.equal(finished[0]!.messageId, "op1:message:0");
     assert.equal(finished[1]!.messageId, "op1:message:1");
     assert.notEqual(finished[0]!.messageId, finished[1]!.messageId);
-    assert.equal(finished[0]!.payload.blocks?.[0]?.text, "First");
-    assert.equal(finished[1]!.payload.blocks?.[0]?.text, "Second");
+    assert.equal(finishedText(finished[0]!), "First");
+    assert.equal(finishedText(finished[1]!), "Second");
     assert.equal(
       f.events.find((event) => event.type === "turn.terminal")!.payload
         .execution,

--- a/packages/pi-tidy-bots/test/codex-adapter.test.ts
+++ b/packages/pi-tidy-bots/test/codex-adapter.test.ts
@@ -220,10 +220,15 @@ test("Codex open/submit/stream/close uses app-server not Chat Completions", asyn
     const opened = (await f.host.request("session.open", f.open)) as {
       nativeReference: string;
       continuity: string;
+      proof: string;
     };
     assert.match(opened.nativeReference, /^codex:thr-fixture-/);
     assert.equal(opened.continuity, "unverified");
-    // New sessions stay unverified. Load continuity is proven separately.
+    assert.equal(opened.proof, "none");
+    assert.equal(f.host.capabilities.sessions.proof, "identity-only");
+    assert.equal(f.host.capabilities.sessions.emptySeat, "non-restorable");
+    assert.notEqual(f.host.capabilities.sessions.proof, "retained-history");
+    // New sessions stay unverified. Load proof is identity-only, not history.
     assert.equal(
       ((await f.host.request("operation.submit", f.submit("hello"))) as {
         disposition: string;
@@ -473,8 +478,22 @@ test("Codex load restores the same native thread across adapter restart", async 
         operationId: "opening-2",
         mode: "load",
         nativeReference: first.nativeReference,
-      })) as { nativeReference: string };
+      })) as {
+        nativeReference: string;
+        continuity: string;
+        proof: string;
+        evidence?: { provenance?: string; threadId?: string };
+      };
       assert.equal(loaded.nativeReference, first.nativeReference);
+      assert.equal(loaded.continuity, "verified");
+      assert.equal(loaded.proof, "identity-only");
+      assert.notEqual(loaded.proof, "retained-history");
+      assert.deepEqual(loaded.evidence, {
+        provenance: "codex-thread-identity",
+        expectedHome: true,
+        threadId: first.nativeReference.slice("codex:".length),
+      });
+      assert.equal(reload.capabilities.sessions.proof, "identity-only");
       assert.equal(
         (
           (await reload.request("operation.submit", {

--- a/packages/pi-tidy-bots/test/codex-adapter.test.ts
+++ b/packages/pi-tidy-bots/test/codex-adapter.test.ts
@@ -238,6 +238,46 @@ test("Codex open/submit/stream/close uses app-server not Chat Completions", asyn
   }
 });
 
+test("two Codex assistant items stay two finished messages", async () => {
+  const f = await setup();
+  try {
+    await f.host.request("session.open", f.open);
+    assert.equal(
+      (
+        (await f.host.request(
+          "operation.submit",
+          f.submit("[multi-item]")
+        )) as { disposition: string }
+      ).disposition,
+      "accepted"
+    );
+    await until(() =>
+      f.events.some((event) => event.type === "turn.terminal")
+    );
+    const finished = f.events.filter(
+      (event) => event.type === "message.finished"
+    );
+    assert.equal(finished.length, 2);
+    assert.equal(finished[0]!.messageId, "op1:message:0");
+    assert.equal(finished[1]!.messageId, "op1:message:1");
+    assert.notEqual(finished[0]!.messageId, finished[1]!.messageId);
+    assert.equal(finished[0]!.payload.blocks?.[0]?.text, "First");
+    assert.equal(finished[1]!.payload.blocks?.[0]?.text, "Second");
+    assert.equal(
+      f.events.find((event) => event.type === "turn.terminal")!.payload
+        .execution,
+      "ended"
+    );
+    assert.equal(
+      f.events.find((event) => event.type === "turn.terminal")!.payload
+        .observation,
+      "complete"
+    );
+  } finally {
+    await f.cleanup();
+  }
+});
+
 test("stale Codex turn completion does not invent a terminal for the live turn", async () => {
   const f = await setup();
   try {

--- a/packages/pi-tidy-bots/test/codex-runtime.test.ts
+++ b/packages/pi-tidy-bots/test/codex-runtime.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  chmod,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  realpath,
+  rm,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { validateCodexConfiguration } from "../backends/codex/runtime.ts";
+
+const fixtureExecutable = fileURLToPath(
+  new URL("./fixtures/codex-native/app-server.mjs", import.meta.url)
+);
+
+async function fixture() {
+  const dir = await mkdtemp(join(tmpdir(), "tidy-codex-runtime-"));
+  const home = join(dir, "home"),
+    profile = join(dir, "profile");
+  await mkdir(home);
+  await mkdir(profile);
+  const executable = join(dir, "codex-fixture");
+  await copyFile(fixtureExecutable, executable);
+  await chmod(executable, 0o755);
+  return {
+    dir,
+    home,
+    profile,
+    executable,
+    config: {
+      executable,
+      home_dir: home,
+      profile_dir: profile,
+      environment_keys: [],
+    },
+    async cleanup() {
+      await rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+test("Codex configuration maps distinct home_dir and profile_dir onto HOME and CODEX_HOME", async () => {
+  const f = await fixture();
+  try {
+    const valid = await validateCodexConfiguration(f.config);
+    assert.equal(valid.home, await realpath(f.home));
+    assert.equal(valid.profile, await realpath(f.profile));
+    assert.notEqual(valid.home, valid.profile);
+    assert.deepEqual(valid.environment, {
+      HOME: valid.home,
+      CODEX_HOME: valid.profile,
+    });
+    assert.notEqual(valid.environment.HOME, valid.environment.CODEX_HOME);
+    for (const name of ["HOME", "CODEX_HOME", "NODE_OPTIONS", "LD_PRELOAD"])
+      await assert.rejects(
+        validateCodexConfiguration({ ...f.config, environment_keys: [name] }),
+        { code: "invalid_config" }
+      );
+    for (const changes of [
+      { executable: "codex" },
+      { home_dir: "/missing-tidy-directory" },
+      { profile_dir: "/missing-tidy-directory" },
+      { unknown: true },
+    ])
+      await assert.rejects(
+        validateCodexConfiguration({ ...f.config, ...changes }),
+        { code: "invalid_config" }
+      );
+  } finally {
+    await f.cleanup();
+  }
+});

--- a/packages/pi-tidy-bots/test/codex-session.test.ts
+++ b/packages/pi-tidy-bots/test/codex-session.test.ts
@@ -112,6 +112,82 @@ test("cancel losing the race to native completed keeps the receipt completed", a
   assert.deepEqual(f.failures, []);
 });
 
+test("two native assistant items become two authoritative messages", async (t) => {
+  const f = fixture(t);
+  await f.session.open("/tmp");
+  const completion = f.session.submit("op1", "turn1", [
+    { type: "text", text: "multi-item" },
+  ]);
+  await until(() => f.events.some((event) => event.type === "turn.started"));
+  f.notify("item/agentMessage/delta", {
+    threadId: f.threadId,
+    turnId: f.nativeTurnId,
+    itemId: "item-a",
+    delta: "Fir",
+  });
+  f.notify("item/completed", {
+    threadId: f.threadId,
+    turnId: f.nativeTurnId,
+    item: { id: "item-a", type: "agentMessage", text: "First" },
+  });
+  f.notify("item/agentMessage/delta", {
+    threadId: f.threadId,
+    turnId: f.nativeTurnId,
+    itemId: "item-b",
+    delta: "Sec",
+  });
+  f.notify("item/completed", {
+    threadId: f.threadId,
+    turnId: f.nativeTurnId,
+    item: { id: "item-b", type: "agentMessage", text: "Second" },
+  });
+  f.notify("item/completed", {
+    threadId: f.threadId,
+    turnId: f.nativeTurnId,
+    item: { id: "item-a", type: "agentMessage", text: "Third" },
+  });
+  f.notify("item/agentMessage/delta", {
+    threadId: f.threadId,
+    turnId: f.nativeTurnId,
+    itemId: "item-b",
+    delta: "extra",
+  });
+  f.notify("turn/completed", {
+    threadId: f.threadId,
+    turn: { id: f.nativeTurnId, items: [], status: "completed" },
+  });
+  assert.deepEqual(await completion, { disposition: "accepted" });
+  const started = f.events.filter((event) => event.type === "message.started");
+  const finished = f.events.filter((event) => event.type === "message.finished");
+  assert.deepEqual(
+    started.map((event) => [event.messageId, event.payload.order]),
+    [
+      ["op1:message:0", 0],
+      ["op1:message:1", 1],
+    ]
+  );
+  assert.equal(finished.length, 2);
+  assert.equal(finished[0]?.messageId, "op1:message:0");
+  assert.equal(finished[1]?.messageId, "op1:message:1");
+  assert.equal(finished[0]?.payload.blocks?.[0]?.text, "First");
+  assert.equal(finished[1]?.payload.blocks?.[0]?.text, "Second");
+  assert.ok(
+    f.events.findIndex((event) => event.type === "message.finished") <
+      f.events.findIndex((event) => event.type === "turn.terminal")
+  );
+  assert.equal(
+    f.events.some((event) => String(event.payload?.text ?? "").includes("Third")),
+    false
+  );
+  assert.equal(
+    f.events.some((event) =>
+      String(event.payload?.text ?? "").includes("extra")
+    ),
+    false
+  );
+  assert.deepEqual(f.failures, []);
+});
+
 test("native interrupted after cancel still reports cancelled", async (t) => {
   const f = fixture(t);
   await f.session.open("/tmp");

--- a/packages/pi-tidy-bots/test/fixtures/codex-native/app-server.mjs
+++ b/packages/pi-tidy-bots/test/fixtures/codex-native/app-server.mjs
@@ -190,6 +190,55 @@ rl.on("line", (line) => {
       });
       return;
     }
+    if (text.includes("[multi-item]")) {
+      const nativeTurnId = `turn-${++counter}`;
+      const first = { id: "item-a", type: "agentMessage", text: "First" };
+      const second = { id: "item-b", type: "agentMessage", text: "Second" };
+      send({
+        id,
+        result: {
+          turn: { id: nativeTurnId, items: [], status: "inProgress" },
+        },
+      });
+      send({
+        method: "turn/started",
+        params: {
+          threadId: params.threadId,
+          turn: { id: nativeTurnId, items: [], status: "inProgress" },
+        },
+      });
+      for (const item of [first, second]) {
+        send({
+          method: "item/started",
+          params: {
+            threadId: params.threadId,
+            turnId: nativeTurnId,
+            startedAtMs: 1,
+            item,
+          },
+        });
+        send({
+          method: "item/completed",
+          params: {
+            threadId: params.threadId,
+            turnId: nativeTurnId,
+            item,
+          },
+        });
+      }
+      send({
+        method: "turn/completed",
+        params: {
+          threadId: params.threadId,
+          turn: {
+            id: nativeTurnId,
+            items: [first, second],
+            status: "completed",
+          },
+        },
+      });
+      return;
+    }
     if (text.includes("[stale-turn]")) {
       const nativeTurnId = `turn-${++counter}`;
       const staleTurnId = `turn-stale-${counter}`;

--- a/packages/pi-tidy-bots/test/fixtures/gateway-application/backend.mjs
+++ b/packages/pi-tidy-bots/test/fixtures/gateway-application/backend.mjs
@@ -370,6 +370,12 @@ input.on("line", (line) => {
             p.config.discovery === true || p.config.sessionsLoad === true
               ? "verified"
               : "unverified",
+          ...(p.config.discovery === true || p.config.sessionsLoad === true
+            ? {
+                proof: "identity-only",
+                emptySeat: "non-restorable",
+              }
+            : {}),
         },
         output: { text: "snapshots", tools: true, usage: "unknown" },
         operations: {
@@ -424,7 +430,16 @@ input.on("line", (line) => {
     respond(message, {
       status: "opened",
       nativeReference,
-      ...(p.mode === "load" ? { continuity: "verified" } : {}),
+      ...(p.mode === "load"
+        ? {
+            continuity: "verified",
+            proof: "identity-only",
+            evidence: {
+              provenance: "native-identity",
+              nativeReference,
+            },
+          }
+        : { continuity: "unverified", proof: "none" }),
     });
   } else if (message.method === "session.compact") {
     record({ method: "session.compact", ...p });

--- a/packages/pi-tidy-bots/test/gateway-protocol.test.ts
+++ b/packages/pi-tidy-bots/test/gateway-protocol.test.ts
@@ -7,6 +7,7 @@ import {
   encodeFrame,
   FrameDecoder,
   parseRpc,
+  sessionOpenEvidenceMatches,
   validateCapabilities,
   validateEvent,
   validateLimits,
@@ -160,6 +161,75 @@ test("capabilities reject unbacked guarantees and unknown required extensions", 
     () =>
       validateCapabilities({
         ...capabilities(),
+        sessions: {
+          load: true,
+          import: false,
+          continuity: "verified",
+        },
+      }),
+    { code: "invalid_capabilities" }
+  );
+  assert.throws(
+    () =>
+      validateCapabilities({
+        ...capabilities(),
+        sessions: {
+          load: true,
+          import: false,
+          continuity: "verified",
+          proof: "none",
+          emptySeat: "non-restorable",
+        },
+      }),
+    { code: "invalid_capabilities" }
+  );
+  assert.throws(
+    () =>
+      validateCapabilities({
+        ...capabilities(),
+        sessions: {
+          ...capabilities().sessions,
+          proof: "identity-only",
+        },
+      }),
+    { code: "invalid_capabilities" }
+  );
+  assert.deepEqual(
+    validateCapabilities({
+      ...capabilities(),
+      sessions: {
+        load: true,
+        import: false,
+        continuity: "verified",
+        proof: "identity-only",
+        emptySeat: "non-restorable",
+      },
+    }).sessions,
+    {
+      load: true,
+      import: false,
+      continuity: "verified",
+      proof: "identity-only",
+      emptySeat: "non-restorable",
+    }
+  );
+  assert.equal(
+    validateCapabilities({
+      ...capabilities(),
+      sessions: {
+        load: true,
+        import: false,
+        continuity: "verified",
+        proof: "retained-history",
+        emptySeat: "non-restorable",
+      },
+    }).sessions.proof,
+    "retained-history"
+  );
+  assert.throws(
+    () =>
+      validateCapabilities({
+        ...capabilities(),
         "org.example.feature": { required: true },
       }),
     { code: "invalid_capabilities" }
@@ -170,6 +240,48 @@ test("capabilities reject unbacked guarantees and unknown required extensions", 
       "org.example.feature": { required: false },
     })["org.example.feature"],
     { required: false }
+  );
+});
+
+test("session open evidence distinguishes identity-only from retained-history", () => {
+  const identity = {
+    continuity: "verified",
+    proof: "identity-only",
+    evidence: {
+      provenance: "codex-thread-identity",
+      expectedHome: true,
+      threadId: "thr-1",
+    },
+  };
+  const history = {
+    continuity: "verified",
+    proof: "retained-history",
+    evidence: {
+      provenance: "pi-history-checkpoint",
+      messageCount: 1,
+    },
+  };
+  assert.equal(sessionOpenEvidenceMatches(identity, "identity-only"), true);
+  assert.equal(sessionOpenEvidenceMatches(identity, "retained-history"), false);
+  assert.equal(sessionOpenEvidenceMatches(history, "retained-history"), true);
+  assert.equal(sessionOpenEvidenceMatches(history, "identity-only"), false);
+  assert.equal(
+    sessionOpenEvidenceMatches(
+      { continuity: "verified", proof: "identity-only" },
+      "identity-only"
+    ),
+    false
+  );
+  assert.equal(
+    sessionOpenEvidenceMatches(
+      {
+        continuity: "verified",
+        proof: "retained-history",
+        evidence: { provenance: "codex-thread-identity" },
+      },
+      "retained-history"
+    ),
+    false
   );
 });
 
@@ -236,6 +348,26 @@ test("published schemas compile strictly and agree with required capability and 
       operations: { ...capabilities().operations, nativeDedupe: "durable" },
     }),
     false
+  );
+  assert.equal(
+    check({
+      ...capabilities(),
+      sessions: { load: true, import: false, continuity: "verified" },
+    }),
+    false
+  );
+  assert.equal(
+    check({
+      ...capabilities(),
+      sessions: {
+        load: true,
+        import: false,
+        continuity: "verified",
+        proof: "identity-only",
+        emptySeat: "non-restorable",
+      },
+    }),
+    true
   );
   const terminal = {
     bindingId: "b",

--- a/packages/pi-tidy-bots/test/gateway-protocol.test.ts
+++ b/packages/pi-tidy-bots/test/gateway-protocol.test.ts
@@ -262,6 +262,17 @@ test("session open evidence distinguishes identity-only from retained-history", 
     },
   };
   assert.equal(sessionOpenEvidenceMatches(identity, "identity-only"), true);
+  assert.equal(
+    sessionOpenEvidenceMatches(
+      {
+        continuity: "verified",
+        proof: "identity-only",
+        evidence: { provenance: "native-identity", nativeReference: "session:1" },
+      },
+      "identity-only"
+    ),
+    true
+  );
   assert.equal(sessionOpenEvidenceMatches(identity, "retained-history"), false);
   assert.equal(sessionOpenEvidenceMatches(history, "retained-history"), true);
   assert.equal(sessionOpenEvidenceMatches(history, "identity-only"), false);

--- a/packages/pi-tidy-bots/test/hermes-adapter.test.ts
+++ b/packages/pi-tidy-bots/test/hermes-adapter.test.ts
@@ -848,6 +848,8 @@ for (const text of ["hello", "[owned-worker]", "[fleet-send]"]) {
     const f = await setup();
     try {
       assert.equal(f.host.capabilities.sessions.load, true);
+      assert.equal(f.host.capabilities.sessions.proof, "retained-history");
+      assert.equal(f.host.capabilities.sessions.emptySeat, "non-restorable");
       assert.equal(
         f.host.capabilities.interactions.permissions,
         "exact-request"

--- a/packages/pi-tidy-bots/test/pi-adapter.test.ts
+++ b/packages/pi-tidy-bots/test/pi-adapter.test.ts
@@ -1226,7 +1226,14 @@ test("Pi cold load restores exact checkpoint across process replacement without 
     };
     const restored = (await second.request("session.open", load)) as JsonObject;
     assert.equal(restored.continuity, "verified");
+    assert.equal(restored.proof, "retained-history");
     assert.equal(restored.nativeReference, opened.nativeReference);
+    assert.deepEqual(restored.evidence, {
+      provenance: "pi-history-checkpoint",
+      sessionId: checkpoint.history.sessionId,
+      sessionFile: checkpoint.history.file,
+      messageCount: 1,
+    });
     assert.deepEqual(await second.request("session.open", load), restored);
     let effects = await f.effects();
     assert.equal(

--- a/packages/pi-tidy-bots/test/plugin-sdk-runtime.test.ts
+++ b/packages/pi-tidy-bots/test/plugin-sdk-runtime.test.ts
@@ -53,7 +53,7 @@ async function fixture(nativeProfile = false, sessionLoad = false) {
   if (sessionLoad)
     script = script.replace(
       'sessions: { load: false, import: false, continuity: "unverified" }',
-      'sessions: { load: true, import: false, continuity: "verified" }'
+      'sessions: { load: true, import: false, continuity: "verified", proof: "identity-only", emptySeat: "non-restorable" }'
     );
   await writeFile(
     join(artifact, "backend.mjs"),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Astra P1-4 (`profile_dir` required but unused at launch).

Schema already required distinct `home_dir` and `profile_dir`. Validation resolved both, then launch set `HOME` **and** `CODEX_HOME` to `home_dir`. Changing `profile_dir` had no effect.

### Decision: **wire**, not drop

Pi and Hermes already split Unix `HOME` from the native profile store (`PI_CODING_AGENT_DIR` / `HERMES_HOME`). Codex identity-only proof is isolated `CODEX_HOME`. Dropping the field would hide a real native location. Smallest honest fix is the same split:

| Config | Child env | Used for |
|---|---|---|
| `home_dir` | `HOME` | Unix home |
| `profile_dir` | `CODEX_HOME` | Thread store + `initialize.codexHome` |

Open diagnostics report both resolved non-secret paths. Load evidence includes `codexHome`. Distinct `profile_dir` miss still fails closed (`session_not_found`); never silent `thread/start`.

P1-1/P1-2 turn/item behavior and P1-3 proof levels are unchanged.

### Proof

SHA: `35810de08315c5e0b0021bf96d817b7aa3aa1779`

Stacked on #78 @ `48d527a` (`cursor/astra-p1-continuity-proof-26d4`).

Commands (Node v26.7.0):

```
cd packages/pi-tidy-bots
node --import tsx --test --test-concurrency=2 \
  test/codex-runtime.test.ts test/codex-adapter.test.ts test/codex-session.test.ts
# 22 tests, 22 pass, 0 fail

npm run check
# exit 0

npm test --workspace=@mobrienv/pi-tidy-bots
# 689 tests, 683 pass, 0 fail, 6 skipped
# exit 0
```

### Hold

**HOLD MERGE for Hayes/Mikey.** Merge after #78. Prod `:4317` was not contacted.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba78c83c-7441-45f7-ad5b-7a1cfccf7ad8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba78c83c-7441-45f7-ad5b-7a1cfccf7ad8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

