### PR TITLE
fix(pi-tidy-bots): emit bubble final on mid-turn child exit

### DIFF
--- a/packages/pi-tidy-bots/src/daemon.ts
+++ b/packages/pi-tidy-bots/src/daemon.ts
@@ -2271,6 +2271,7 @@ export function startFleet(options: StartFleetOptions): Promise<FleetHandle> {
     code: number | null,
     signal: string | null
   ): void => {
+    const dyingTurnId = runtime.turnId;
     runtime.online = false;
     runtime.session = null;
     runtime.turnId = null;
@@ -2288,7 +2289,7 @@ export function startFleet(options: StartFleetOptions): Promise<FleetHandle> {
     }
     const droppedSources = runtime.pendingFrom;
     runtime.pendingFrom = [];
-    if (runtime.turnId) {
+    if (dyingTurnId) {
       appendTranscript(runtime, {
         id: randomUUID(),
         role: "system",
@@ -2296,7 +2297,12 @@ export function startFleet(options: StartFleetOptions): Promise<FleetHandle> {
         text: "Turn interrupted by a restart — resend if it was mid-flight.",
         ts: new Date().toISOString(),
       });
-      runtime.turnId = null;
+      emit({
+        type: "bubble",
+        bot: runtime.config.name,
+        turnId: dyingTurnId,
+        phase: "final",
+      });
     }
     // Issue 140: the daemon handled this exit (sources notified below)
     // — the marker's recovery job is done. A daemon death skips this,

--- a/packages/pi-tidy-bots/test/handle-exit.test.ts
+++ b/packages/pi-tidy-bots/test/handle-exit.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import WebSocket from "ws";
+
+// handleExit used to null runtime.turnId before the mid-turn interrupt
+// check, so a child death (model-swap respawn, crash) never emitted
+// bubble phase:final. The UI last bubble then stayed stuck. This
+// lifecycle test is the regression: live turnId → SIGKILL → final
+// with that same dying turnId. The stub never settles, so the only
+// legal final is handleExit's.
+
+async function waitFor(
+  probe: () => Promise<boolean> | boolean,
+  timeoutMs = 20000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await probe()) return;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error("waitFor: condition not met in time");
+}
+
+function ledgerPid(fleetDir: string, bot: string): number {
+  const raw = readFileSync(
+    join(fleetDir, ".fleet", "children", `${bot}.pid`),
+    "utf8"
+  ).trim();
+  return Number(
+    raw.startsWith("{") ? (JSON.parse(raw) as { pid: number }).pid : raw
+  );
+}
+
+test(
+  "handleExit lifecycle: mid-turn child death emits bubble phase:final with dying turnId",
+  { timeout: 60000 },
+  async () => {
+    const fleetDir = mkdtempSync(join(tmpdir(), "ptb-handle-exit-"));
+    const handles: Array<{ stop(): Promise<void> }> = [];
+    const hangStub = join(fleetDir, "hang-pi.mjs");
+    writeFileSync(
+      hangStub,
+      `import { createInterface } from "node:readline";
+const send = (frame) => process.stdout.write(JSON.stringify(frame) + "\\n");
+const rl = createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  let request;
+  try { request = JSON.parse(line); } catch { return; }
+  if (request.type === "get_state") {
+    send({ type: "response", id: request.id, success: true, data: { model: { contextWindow: 128000 } } });
+    return;
+  }
+  if (request.type === "get_messages") {
+    send({ type: "response", id: request.id, success: true, data: { messages: [] } });
+    return;
+  }
+  if (request.type === "prompt") {
+    send({ type: "turn_start" });
+    send({ type: "agent_start" });
+    // Hang mid-turn. No agent_settled — the only phase:final must come
+    // from handleExit capturing turnId before it is nulled.
+  }
+  if (request.id !== undefined && request.type) {
+    send({ type: "response", id: request.id, success: true });
+  }
+});
+setInterval(() => {}, 1 << 30);
+`
+    );
+    try {
+      mkdirSync(join(fleetDir, "bots", "aa"), { recursive: true });
+      writeFileSync(join(fleetDir, "bots", "aa", "AGENTS.md"), "# aa\n");
+      writeFileSync(
+        join(fleetDir, "bots.toml"),
+        `[[bot]]\nname = "aa"\ndir = "bots/aa"\n`
+      );
+      const wrapper = join(fleetDir, "pi.sh");
+      writeFileSync(wrapper, `#!/bin/sh\nexec node ${hangStub}\n`);
+      spawnSync("chmod", ["+x", wrapper]);
+
+      const { startFleet } = await import("../src/daemon.ts");
+      const handle = await startFleet({
+        dir: fleetDir,
+        port: 0,
+        host: "127.0.0.1",
+        piBin: wrapper,
+        log: () => {},
+      });
+      handles.push(handle);
+      const base = `http://127.0.0.1:${handle.port}`;
+      await waitFor(async () =>
+        (
+          (await (await fetch(`${base}/api/fleet`)).json()) as {
+            bots: { online: boolean }[];
+          }
+        ).bots.every((b) => b.online)
+      );
+
+      const bubbles: {
+        type: string;
+        phase?: string;
+        turnId?: string | null;
+        bot?: string;
+      }[] = [];
+      const ws = new WebSocket(`ws://127.0.0.1:${handle.port}/api/ws`);
+      ws.on("message", (raw) => {
+        const frame = JSON.parse(String(raw)) as (typeof bubbles)[number];
+        if (frame.type === "bubble") bubbles.push(frame);
+      });
+      await new Promise<void>((resolve, reject) => {
+        ws.once("open", () => resolve());
+        ws.once("error", reject);
+      });
+
+      void fetch(`${base}/api/bots/aa/message`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ text: "stay mid-turn" }),
+      });
+
+      await waitFor(() =>
+        bubbles.some(
+          (frame) =>
+            frame.phase === "working" &&
+            typeof frame.turnId === "string" &&
+            frame.turnId.length > 0
+        )
+      );
+      const dyingTurnId = bubbles.find(
+        (frame) => frame.phase === "working" && typeof frame.turnId === "string"
+      )?.turnId;
+      assert.equal(typeof dyingTurnId, "string");
+      assert.ok(dyingTurnId && dyingTurnId.length > 0);
+
+      const pid = ledgerPid(fleetDir, "aa");
+      assert.ok(Number.isFinite(pid) && pid > 0, "child ledger pid");
+      process.kill(pid, "SIGKILL");
+
+      await waitFor(() =>
+        bubbles.some(
+          (frame) =>
+            frame.phase === "final" &&
+            frame.turnId === dyingTurnId &&
+            frame.bot === "aa"
+        )
+      );
+      const finals = bubbles.filter(
+        (frame) => frame.phase === "final" && frame.turnId === dyingTurnId
+      );
+      assert.equal(
+        finals.length,
+        1,
+        "exactly one handleExit final for the dying turn"
+      );
+
+      const transcript = async () =>
+        (
+          (await (await fetch(`${base}/api/bots/aa/transcript`)).json()) as {
+            transcript: { role: string; text: string }[];
+          }
+        ).transcript;
+      await waitFor(async () =>
+        (await transcript()).some(
+          (entry) =>
+            entry.role === "system" &&
+            entry.text.includes("Turn interrupted by a restart")
+        )
+      );
+
+      ws.close();
+    } finally {
+      await Promise.all(handles.map((h) => h.stop().catch(() => {})));
+      rmSync(fleetDir, { recursive: true, force: true });
+    }
+  }
+);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**HOLD MERGE for Mikey/Hayes.** Do not merge until they review.

## Root cause

`handleExit` in `packages/pi-tidy-bots/src/daemon.ts` cleared `runtime.turnId` before the mid-turn interrupt check. A child death during model-swap respawn (or any mid-turn crash) never emitted bubble `phase: final`, so the Flutter/console last bubble stayed stuck.

## Fix

Capture the dying turn id **before** nulling. If one exists, keep the existing "Turn interrupted by a restart" system entry and emit:

```ts
emit({
  type: "bubble",
  bot: runtime.config.name,
  turnId: dyingTurnId,
  phase: "final",
});
```

This is the uncommitted rook patch at main `@ 2c45a90`, now on branch `cursor/sticky-bubble-final-7f28` (not left dirty on main).

## Test

`packages/pi-tidy-bots/test/handle-exit.test.ts`

- Hang stub: `agent_start` then never settle (so the only legal `phase: final` is `handleExit`).
- Observe the live `working` bubble `turnId`.
- `SIGKILL` the child via the pid ledger.
- Assert bubble `phase: final` with that dying `turnId`, plus the interrupt system entry.

Command (from `packages/pi-tidy-bots`):

```sh
node --import tsx --test --test-name-pattern='handleExit lifecycle' test/handle-exit.test.ts
```

**Focused run:** exit 0 — 1 pass / 0 fail (1124ms).

**Pre-commit suite on `6ee3d0a`:** handle-exit passed (820ms). `pi-tidy-bots` 690 tests / 683 pass / 0 fail.

## ESRCH

Restart CLI **ESRCH** was reported around the fleet restart (process already gone). Not reproduced in this slice (no `ESRCH` in current `.fleet/logs/daemon.log`). Stop's `SIGTERM` already treats ESRCH as "died between liveness probe and signal"; `pidAlive` treats kill-0 ESRCH as dead. Not chased. Prod `:4317` was not restarted or mutated.

## Out of scope

- Prod fleet beyond the already-applied local patch
- Restart-CLI ESRCH hardening (process-already-gone race; not trivial-enough to sneak in)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8092cf2-633d-4c34-8d28-cefb1e1f7f28?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8092cf2-633d-4c34-8d28-cefb1e1f7f28&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

